### PR TITLE
Improve Import Performance

### DIFF
--- a/cmd/got/main.go
+++ b/cmd/got/main.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"log"
-
 	"github.com/gotvc/got/pkg/gotcmd"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	if err := gotcmd.Execute(); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gotvc/got
 go 1.15
 
 require (
-	github.com/brendoncarroll/go-p2p v0.0.0-20210819000259-cc04d176d6c1
-	github.com/brendoncarroll/go-state v0.0.0-20210724154322-8779b9922848
+	github.com/brendoncarroll/go-p2p v0.0.0-20210822202912-45e39d4c6c98
+	github.com/brendoncarroll/go-state v0.0.0-20210903012623-d006328d202b
 	github.com/chmduquesne/rollinghash v0.0.0-20180912150627-a60f8e7142b5
 	github.com/golang/protobuf v1.4.3
 	github.com/hashicorp/golang-lru v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.15
 
 require (
 	github.com/brendoncarroll/go-p2p v0.0.0-20210822202912-45e39d4c6c98
-	github.com/brendoncarroll/go-state v0.0.0-20210903012623-d006328d202b
+	github.com/brendoncarroll/go-state v0.0.0-20210911170157-d8e2409f8669
 	github.com/chmduquesne/rollinghash v0.0.0-20180912150627-a60f8e7142b5
 	github.com/golang/protobuf v1.4.3
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/inet256/inet256 v0.0.0-20210821194658-7c45d7ba4501
+	github.com/minio/highwayhash v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -45,11 +45,12 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bkaradzic/go-lz4 v0.0.0-20160924222819-7224d8d8f27e h1:2augTYh6E+XoNrrivZJBadpThP/dsvYKj0nzqfQ8tM4=
 github.com/bkaradzic/go-lz4 v0.0.0-20160924222819-7224d8d8f27e/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
-github.com/brendoncarroll/go-p2p v0.0.0-20210819000259-cc04d176d6c1 h1:p4ft2Ml7/p9WzUVvE/Ep6Z+dEpoghGyip/P4eAMF+RA=
 github.com/brendoncarroll/go-p2p v0.0.0-20210819000259-cc04d176d6c1/go.mod h1:tXEfapNF/whaBeE9HD6wY/QofRZ0Sr01aAtQNB1Le9s=
+github.com/brendoncarroll/go-p2p v0.0.0-20210822202912-45e39d4c6c98 h1:3fLj68q5oPFpujVXnNuh0OpPT9C0ljFQ85QwH9H7Ekg=
+github.com/brendoncarroll/go-p2p v0.0.0-20210822202912-45e39d4c6c98/go.mod h1:tXEfapNF/whaBeE9HD6wY/QofRZ0Sr01aAtQNB1Le9s=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040/go.mod h1:EQKdXJyc93dh3yN1wRYdKjAZk+MutF5DFwoW+Vqe5U0=
-github.com/brendoncarroll/go-state v0.0.0-20210724154322-8779b9922848 h1:WqRA4Lo7fpt0GF6AJGhMhT1E9HBHDfwWIsDjxWb4gw8=
-github.com/brendoncarroll/go-state v0.0.0-20210724154322-8779b9922848/go.mod h1:M86VCqKTis4CJcSvWCoB1OZHuRu3d1c05iS7+6HbBQI=
+github.com/brendoncarroll/go-state v0.0.0-20210903012623-d006328d202b h1:bHa85YZwok4xYzioiP8D8pTMhkafkU4nNxSzKx1pWCM=
+github.com/brendoncarroll/go-state v0.0.0-20210903012623-d006328d202b/go.mod h1:M86VCqKTis4CJcSvWCoB1OZHuRu3d1c05iS7+6HbBQI=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/calmh/xdr v1.1.0/go.mod h1:E8sz2ByAdXC8MbANf1LCRYzedSnnc+/sXXJs/PVqoeg=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/brendoncarroll/go-p2p v0.0.0-20210819000259-cc04d176d6c1/go.mod h1:tX
 github.com/brendoncarroll/go-p2p v0.0.0-20210822202912-45e39d4c6c98 h1:3fLj68q5oPFpujVXnNuh0OpPT9C0ljFQ85QwH9H7Ekg=
 github.com/brendoncarroll/go-p2p v0.0.0-20210822202912-45e39d4c6c98/go.mod h1:tXEfapNF/whaBeE9HD6wY/QofRZ0Sr01aAtQNB1Le9s=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040/go.mod h1:EQKdXJyc93dh3yN1wRYdKjAZk+MutF5DFwoW+Vqe5U0=
-github.com/brendoncarroll/go-state v0.0.0-20210903012623-d006328d202b h1:bHa85YZwok4xYzioiP8D8pTMhkafkU4nNxSzKx1pWCM=
-github.com/brendoncarroll/go-state v0.0.0-20210903012623-d006328d202b/go.mod h1:M86VCqKTis4CJcSvWCoB1OZHuRu3d1c05iS7+6HbBQI=
+github.com/brendoncarroll/go-state v0.0.0-20210911170157-d8e2409f8669 h1:s4Yp+YnLbI/4WynSOKxpnhTy+cUM1w8m7IV1RfQF3Gk=
+github.com/brendoncarroll/go-state v0.0.0-20210911170157-d8e2409f8669/go.mod h1:M86VCqKTis4CJcSvWCoB1OZHuRu3d1c05iS7+6HbBQI=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/calmh/xdr v1.1.0/go.mod h1:E8sz2ByAdXC8MbANf1LCRYzedSnnc+/sXXJs/PVqoeg=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
@@ -284,6 +284,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
+github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/miscreant/miscreant.go v0.0.0-20200214223636-26d376326b75 h1:cUVxyR+UfmdEAZGJ8IiKld1O0dbGotEnkMolG5hfMSY=
@@ -571,6 +573,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/branches/spaces_test.go
+++ b/pkg/branches/spaces_test.go
@@ -14,7 +14,7 @@ func TestMemSpace(t *testing.T) {
 
 func newTestSpace(t testing.TB) Space {
 	newStore := func() cadata.Store {
-		return cadata.NewMem(1 << 20)
+		return cadata.NewMem(cadata.DefaultHash, 1<<20)
 	}
 	newCell := func() cells.Cell {
 		return cells.NewMem()

--- a/pkg/branches/volume.go
+++ b/pkg/branches/volume.go
@@ -3,7 +3,6 @@ package branches
 import (
 	"context"
 	"encoding/json"
-	"log"
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/brendoncarroll/go-state/cells"
@@ -12,6 +11,7 @@ import (
 	"github.com/gotvc/got/pkg/gotvc"
 	"github.com/gotvc/got/pkg/stores"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type Snap = gotvc.Snap
@@ -102,8 +102,8 @@ type Triple struct {
 }
 
 func syncStores(ctx context.Context, dst, src Triple, snap gotvc.Snapshot) error {
-	log.Println("begin syncing stores")
-	defer log.Println("done syncing stores")
+	logrus.Println("begin syncing stores")
+	defer logrus.Println("done syncing stores")
 	return gotvc.Sync(ctx, dst.VC, src.VC, snap, func(root gotfs.Root) error {
 		return gotfs.Sync(ctx, dst.FS, src.FS, root, func(ref gdat.Ref) error {
 			return cadata.Copy(ctx, dst.Raw, src.Raw, ref.CID)
@@ -130,11 +130,11 @@ func CleanupVolume(ctx context.Context, vol Volume) error {
 		}
 	}
 	for i := range keep {
-		log.Printf("keeping %d blobs", keep[i].Count())
+		logrus.Printf("keeping %d blobs", keep[i].Count())
 		if count, err := filterStore(ctx, ss[i], keep[i]); err != nil {
 			return err
 		} else {
-			log.Printf("deleted %d blobs", count)
+			logrus.Printf("deleted %d blobs", count)
 		}
 	}
 	return nil

--- a/pkg/chunking/chunker_test.go
+++ b/pkg/chunking/chunker_test.go
@@ -17,7 +17,8 @@ func TestChunker(t *testing.T) {
 
 	var count int
 	var size int
-	c := NewContentDefined(avgSize, maxSize, nil, func(data []byte) error {
+	poly := DerivePolynomial(nil)
+	c := NewContentDefined(64, avgSize, maxSize, poly, func(data []byte) error {
 		count++
 		size += len(data)
 		require.LessOrEqual(t, len(data), maxSize)

--- a/pkg/chunking/content_defined.go
+++ b/pkg/chunking/content_defined.go
@@ -2,62 +2,73 @@ package chunking
 
 import (
 	"bytes"
-	"encoding/binary"
 	"math/bits"
 
-	"github.com/chmduquesne/rollinghash/buzhash64"
-	"github.com/gotvc/got/pkg/gdat"
-	"github.com/pkg/errors"
+	"github.com/chmduquesne/rollinghash/rabinkarp64"
+	"golang.org/x/crypto/blake2b"
 )
 
+const windowSize = 64
+
+type rollingHash = rabinkarp64.RabinKarp64
+
 type ContentDefined struct {
-	log2AvgSize, maxSize int
-	onChunk              func(data []byte) error
-	hashes               *[256]uint64
-	rh                   *buzhash64.Buzhash64
-	buf                  bytes.Buffer
+	avgBits          int
+	minSize, maxSize int
+	onChunk          func(data []byte) error
+	rh               *rollingHash
+	buf              bytes.Buffer
 }
 
-func NewContentDefined(avgSize, maxSize int, hashes *[256]uint64, onChunk func(data []byte) error) *ContentDefined {
+func NewContentDefined(minSize, avgSize, maxSize int, pol rabinkarp64.Pol, onChunk func(data []byte) error) *ContentDefined {
 	if bits.OnesCount(uint(avgSize)) != 1 {
 		panic("avgSize must be power of 2")
 	}
-	if hashes == nil {
-		hs := buzhash64.GenerateHashes(1)
-		hashes = &hs
+	if pol == 0 {
+		panic("pol must be non-zero")
+	}
+	if minSize < windowSize {
+		panic("minSize must be larger than 64")
 	}
 	log2AvgSize := bits.TrailingZeros64(uint64(avgSize))
-	rh := buzhash64.NewFromUint64Array(*hashes)
-	rh.Write(make([]byte, 64))
-	return &ContentDefined{
-		log2AvgSize: log2AvgSize,
-		maxSize:     maxSize,
-		onChunk:     onChunk,
-		rh:          rh,
-		hashes:      hashes,
+	rh := rabinkarp64.NewFromPol(pol)
+	c := &ContentDefined{
+		avgBits: log2AvgSize,
+		minSize: minSize,
+		maxSize: maxSize,
+		onChunk: onChunk,
+		rh:      rh,
 	}
+	c.Reset()
+	return c
 }
 
 func (c *ContentDefined) Write(data []byte) (int, error) {
-	var copied int
-	for n := range data {
-		c.rh.Roll(data[n])
-		if atChunkBoundary(c.rh.Sum64(), c.log2AvgSize) || n+c.Buffered() == c.maxSize {
-			n2, _ := c.buf.Write(data[copied:n])
-			copied += n2
+	for i := range data {
+		if err := c.WriteByte(data[i]); err != nil {
+			return i, err
+		}
+		if c.atChunkBoundary(c.rh, &c.buf) {
 			if err := c.emit(); err != nil {
-				return copied, err
+				return i, err
 			}
 		}
 	}
-	c.buf.Write(data[copied:])
 	return len(data), nil
+}
+
+func (c *ContentDefined) WriteByte(b byte) error {
+	roll(c.rh, &c.buf, b)
+	return nil
+}
+
+func (c *ContentDefined) atChunkBoundary(rh *rollingHash, buf *bytes.Buffer) bool {
+	return buf.Len() >= c.minSize && (atChunkBoundary(rh.Sum64(), c.avgBits) || buf.Len() >= c.maxSize)
 }
 
 func (c *ContentDefined) emit() error {
 	defer func() {
 		c.Reset()
-
 	}()
 	if c.buf.Len() > 0 {
 		return c.onChunk(c.buf.Bytes())
@@ -72,67 +83,35 @@ func (c *ContentDefined) Buffered() int {
 func (c *ContentDefined) Reset() {
 	c.buf.Reset()
 	c.rh.Reset()
-	c.rh.Write(make([]byte, 64))
-}
-
-func (c *ContentDefined) WriteNoSplit(data []byte) error {
-	if len(data) > c.maxSize {
-		return errors.Errorf("cannot write data larger than max size")
-	}
-	// have to split, before
-	if c.WouldOverflow(data) {
-		if err := c.Flush(); err != nil {
-			return err
-		}
-		return c.WriteNoSplit(data)
-	}
-	// write then split
-	if c.WouldSplit(data) {
-		c.buf.Write(data)
-		return c.Flush()
-	}
-	_, err := c.Write(data)
-	return err
-}
-
-// WouldOverflow returns whether the data would exceed the maximum chunk size, given the buffered data.
-func (c *ContentDefined) WouldOverflow(data []byte) bool {
-	return len(data)+c.buf.Len() > c.maxSize
-}
-
-// WouldSplit returns whether the data would be split by the chunking algorithm, given the buffered data.
-func (c *ContentDefined) WouldSplit(data []byte) bool {
-	rh := buzhash64.NewFromUint64Array(*c.hashes)
-	rh.Write(make([]byte, 64))
-	for _, b := range c.buf.Bytes() {
-		rh.Roll(b)
-	}
-	for _, b := range data {
-		rh.Roll(b)
-		if atChunkBoundary(rh.Sum64(), c.log2AvgSize) {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *ContentDefined) Flush() error {
 	return c.emit()
 }
 
+func roll(rh *rollingHash, buf *bytes.Buffer, b byte) {
+	if buf.Len() < windowSize {
+		rh.Write([]byte{b})
+	} else {
+		rh.Roll(b)
+	}
+	buf.WriteByte(b)
+}
+
 func atChunkBoundary(sum uint64, nbits int) bool {
 	return bits.TrailingZeros64(sum) >= nbits
 }
 
-func DeriveHashes(seed []byte) *[256]uint64 {
-	const purpose = "buzzhash64"
-	buf := make([]byte, 256*8)
-	gdat.DeriveKey(buf, seed, []byte(purpose))
-	hashes := [256]uint64{}
-	for i := range hashes {
-		start := i * 8
-		end := (i + 1) * 8
-		hashes[i] = binary.BigEndian.Uint64(buf[start:end])
+func DerivePolynomial(seed []byte) rabinkarp64.Pol {
+	const purpose = "rabinkarp64"
+	xof, err := blake2b.NewXOF(blake2b.OutputLengthUnknown, seed)
+	if err != nil {
+		panic(err)
 	}
-	return &hashes
+	xof.Write([]byte(purpose))
+	poly, err := rabinkarp64.DerivePolynomial(xof)
+	if err != nil {
+		panic(err)
+	}
+	return poly
 }

--- a/pkg/gdat/crypto.go
+++ b/pkg/gdat/crypto.go
@@ -10,6 +10,10 @@ import (
 	"golang.org/x/crypto/chacha20"
 )
 
+func Hash(x []byte) cadata.ID {
+	return blake2b.Sum256(x)
+}
+
 // DeriveKey uses the blake2b XOF to fill out.
 // The input to the XOF is additional and secret is used to key the XOF.
 func DeriveKey(out, secret, additional []byte) {
@@ -59,8 +63,7 @@ func (*DEK) String() string {
 }
 
 func postEncrypt(ctx context.Context, s cadata.Poster, keyFunc KeyFunc, data []byte) (cadata.ID, *DEK, error) {
-	id := cadata.DefaultHash(data)
-	dek := keyFunc(id)
+	dek := keyFunc(Hash(data))
 	ctext := make([]byte, len(data))
 	cryptoXOR(dek, ctext, data)
 	id, err := s.Post(ctx, ctext)

--- a/pkg/gdat/refs_test.go
+++ b/pkg/gdat/refs_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestMarshalUnmarshal(t *testing.T) {
 	ctx := context.Background()
-	s := cadata.NewMem(cadata.DefaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := NewOperator()
 	x, err := op.Post(ctx, s, []byte("test data"))
 	require.NoError(t, err)

--- a/pkg/gotcmd/debug.go
+++ b/pkg/gotcmd/debug.go
@@ -1,9 +1,13 @@
 package gotcmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/gotvc/got/pkg/gdat"
+	"github.com/spf13/cobra"
+)
 
 func init() {
 	rootCmd.AddCommand(debugCmd)
+	rootCmd.AddCommand(derefCmd)
 }
 
 var debugCmd = &cobra.Command{
@@ -21,5 +25,25 @@ var debugCmd = &cobra.Command{
 		default:
 			return nil
 		}
+	},
+}
+
+var derefCmd = &cobra.Command{
+	Use:     "deref",
+	PreRunE: loadRepo,
+	Hidden:  true,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		p := args[0]
+		var ref gdat.Ref
+		if err := ref.UnmarshalText([]byte(p)); err != nil {
+			return err
+		}
+		s := repo.UnionStore()
+		dop := gdat.NewOperator()
+		return dop.GetF(ctx, s, ref, func(data []byte) error {
+			_, err := cmd.OutOrStdout().Write(data)
+			return err
+		})
 	},
 }

--- a/pkg/gotfs/builder.go
+++ b/pkg/gotfs/builder.go
@@ -57,8 +57,8 @@ func (b *builder) Write(p []byte) (int, error) {
 	return b.w.Write(p)
 }
 
-func (b *builder) CopyFrom(ctx context.Context, root Root) error {
-	it := b.o.gotkv.NewIterator(b.ms, root, gotkv.TotalSpan())
+func (b *builder) CopyFrom(ctx context.Context, root Root, span gotkv.Span) error {
+	it := b.o.gotkv.NewIterator(b.ms, root, span)
 	return gotkv.CopyAll(ctx, b.mBuilder, it)
 }
 
@@ -73,10 +73,6 @@ func (b *builder) CopyExtent(ctx context.Context, ext *Extent) error {
 		_, err := b.w.Write(data)
 		return err
 	})
-}
-
-func (b *builder) CopyFromIterator(ctx context.Context, it gotkv.Iterator) error {
-	return gotkv.CopyAll(ctx, b.mBuilder, it)
 }
 
 // PutExtent write an entry for the extent

--- a/pkg/gotfs/builder.go
+++ b/pkg/gotfs/builder.go
@@ -1,0 +1,110 @@
+package gotfs
+
+import (
+	"context"
+	"io/fs"
+	"runtime"
+	sync "sync"
+
+	"github.com/gotvc/got/pkg/gotkv"
+	"github.com/gotvc/got/pkg/stores"
+)
+
+type builder struct {
+	o        *Operator
+	ctx      context.Context
+	ms, ds   Store
+	ads      *stores.AsyncStore
+	w        *writer
+	mBuilder gotkv.Builder
+	path     *string
+	offset   uint64
+
+	finishOnce sync.Once
+	root       *Root
+	err        error
+}
+
+func (o *Operator) newBuilder(ctx context.Context, ms, ds Store) *builder {
+	b := &builder{
+		o:   o,
+		ctx: ctx,
+		ms:  ms,
+		ds:  ds,
+		ads: stores.NewAsyncStore(ms, runtime.GOMAXPROCS(0)),
+	}
+	b.w = o.newWriter(ctx, b.ads, b.handleExtent)
+	b.mBuilder = o.gotkv.NewBuilder(b.ms)
+	return b
+}
+
+func (b *builder) PutMetadata(p string, md *Metadata) error {
+	p = cleanPath(p)
+	if fs.FileMode(md.Mode).IsRegular() {
+		if err := b.w.Flush(); err != nil {
+			return err
+		}
+	}
+	if err := checkPath(p); err != nil {
+		return err
+	}
+	b.path = &p
+	k := makeMetadataKey(p)
+	return b.mBuilder.Put(b.ctx, k, md.marshal())
+}
+
+func (b *builder) Write(p []byte) (int, error) {
+	return b.w.Write(p)
+}
+
+func (b *builder) CopyFrom(ctx context.Context, root Root) error {
+	it := b.o.gotkv.NewIterator(b.ms, root, gotkv.TotalSpan())
+	return gotkv.CopyAll(ctx, b.mBuilder, it)
+}
+
+func (b *builder) CopyExtent(ctx context.Context, ext *Extent) error {
+	if b.w.Buffered() == 0 {
+		p := *b.path
+		offset := b.offset
+		b.offset += uint64(ext.Length)
+		return b.putExtent(p, offset, ext)
+	}
+	return b.o.getExtentF(ctx, b.ds, ext, func(data []byte) error {
+		_, err := b.w.Write(data)
+		return err
+	})
+}
+
+func (b *builder) CopyFromIterator(ctx context.Context, it gotkv.Iterator) error {
+	return gotkv.CopyAll(ctx, b.mBuilder, it)
+}
+
+// PutExtent write an entry for the extent
+func (b *builder) putExtent(p string, start uint64, ext *Extent) error {
+	k := makeExtentKey(p, start+uint64(ext.Length))
+	return b.mBuilder.Put(b.ctx, k, ext.marshal())
+}
+
+func (b *builder) handleExtent(ext *Extent) error {
+	p := *b.path
+	offset := b.offset
+	b.offset += uint64(ext.Length)
+	return b.putExtent(p, offset, ext)
+}
+
+func (b *builder) Finish() (*Root, error) {
+	b.finishOnce.Do(func() {
+		b.root, b.err = b.finish()
+	})
+	return b.root, b.err
+}
+
+func (b *builder) finish() (*Root, error) {
+	if err := b.w.Flush(); err != nil {
+		return nil, err
+	}
+	if err := b.ads.Close(); err != nil {
+		return nil, err
+	}
+	return b.mBuilder.Finish(b.ctx)
+}

--- a/pkg/gotfs/files_test.go
+++ b/pkg/gotfs/files_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCreateFileFrom(t *testing.T) {
 	ctx := context.Background()
-	s := cadata.NewMem(DefaultMaxBlobSize)
+	s := cadata.NewMem(cadata.DefaultHash, DefaultMaxBlobSize)
 	op := NewOperator()
 	x, err := op.NewEmpty(ctx, s)
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestCreateFileFrom(t *testing.T) {
 
 func TestFileMetadata(t *testing.T) {
 	ctx := context.Background()
-	s := cadata.NewMem(DefaultMaxBlobSize)
+	s := cadata.NewMem(cadata.DefaultHash, DefaultMaxBlobSize)
 	op := NewOperator()
 	x, err := op.NewEmpty(ctx, s)
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestFileMetadata(t *testing.T) {
 
 func TestLargeFiles(t *testing.T) {
 	ctx := context.Background()
-	s := cadata.NewMem(DefaultMaxBlobSize)
+	s := cadata.NewMem(cadata.DefaultHash, DefaultMaxBlobSize)
 	op := NewOperator()
 
 	const N = 5

--- a/pkg/gotfs/writer.go
+++ b/pkg/gotfs/writer.go
@@ -31,7 +31,7 @@ func (o *Operator) newWriter(ctx context.Context, s cadata.Store, onExtent exten
 		s:        s,
 		onExtent: onExtent,
 	}
-	w.chunker = chunking.NewContentDefined(o.averageSizeData, o.maxBlobSize, o.hashes, w.onChunk)
+	w.chunker = chunking.NewContentDefined(o.minSizeData, o.averageSizeData, o.maxBlobSize, o.poly, w.onChunk)
 	return w
 }
 
@@ -57,8 +57,5 @@ func (w *writer) onChunk(data []byte) error {
 		Length: uint32(len(data)),
 		Ref:    gdat.MarshalRef(*ref),
 	}
-	if err := w.onExtent(ext); err != nil {
-		return err
-	}
-	return nil
+	return w.onExtent(ext)
 }

--- a/pkg/gotkv/kv_test.go
+++ b/pkg/gotkv/kv_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewEmpty(t *testing.T) {
 	ctx := context.Background()
-	s := cadata.NewMem(cadata.DefaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := newTestOperator(t)
 	x, err := op.NewEmpty(ctx, s)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestPutGetMany(t *testing.T) {
 func testSetup(t *testing.T) (context.Context, cadata.Store, *Root) {
 	ctx := context.Background()
 	op := newTestOperator(t)
-	s := cadata.NewMem(cadata.DefaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	x, err := op.NewEmpty(ctx, s)
 	require.NoError(t, err)
 	return ctx, s, x

--- a/pkg/gotkv/ptree/kv.go
+++ b/pkg/gotkv/ptree/kv.go
@@ -23,6 +23,10 @@ type Span struct {
 	Start, End []byte
 }
 
+func (s Span) String() string {
+	return fmt.Sprintf("[%q, %q)", s.Start, s.End)
+}
+
 func TotalSpan() Span {
 	return Span{}
 }

--- a/pkg/gotkv/ptree/kv_test.go
+++ b/pkg/gotkv/ptree/kv_test.go
@@ -13,7 +13,7 @@ import (
 func TestAddPrefix(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	s := cadata.NewMem(defaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, defaultMaxSize)
 	op := gdat.NewOperator()
 	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
 

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -186,6 +186,7 @@ type Iterator struct {
 	op   *gdat.Operator
 	root Root
 	span Span
+	pos  []byte
 }
 
 func NewIterator(s cadata.Store, op *gdat.Operator, root Root, span Span) *Iterator {
@@ -195,6 +196,7 @@ func NewIterator(s cadata.Store, op *gdat.Operator, root Root, span Span) *Itera
 		root: root,
 		span: span.Clone(),
 	}
+	it.pos = it.span.Start
 	return it
 }
 
@@ -219,7 +221,7 @@ func (it *Iterator) Peek(ctx context.Context) (*Entry, error) {
 }
 
 func (it *Iterator) peek(ctx context.Context) (int, *Entry, error) {
-	return peekTree(ctx, it.s, it.op, it.root, it.span.Start)
+	return peekTree(ctx, it.s, it.op, it.root, it.pos)
 }
 
 func (it *Iterator) Seek(ctx context.Context, k []byte) error {
@@ -228,12 +230,12 @@ func (it *Iterator) Seek(ctx context.Context, k []byte) error {
 }
 
 func (it *Iterator) setPos(k []byte) {
-	it.span.Start = append(it.span.Start[:0], k...)
+	it.pos = append(it.pos[:0], k...)
 }
 
 func (it *Iterator) setPosAfter(k []byte) {
 	it.setPos(k)
-	it.span.Start = append(it.span.Start, 0x00)
+	it.pos = append(it.pos, 0x00)
 }
 
 func peekEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index, gteq []byte) (*Entry, error) {

--- a/pkg/gotkv/ptree/ptree_test.go
+++ b/pkg/gotkv/ptree/ptree_test.go
@@ -15,7 +15,7 @@ import (
 func TestBuilder(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	s := cadata.NewMem(cadata.DefaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := gdat.NewOperator()
 	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
 
@@ -31,7 +31,7 @@ func TestBuilder(t *testing.T) {
 func TestBuildIterate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	s := cadata.NewMem(cadata.DefaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := gdat.NewOperator()
 	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
 
@@ -57,7 +57,7 @@ func TestBuildIterate(t *testing.T) {
 func TestMutate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	s := cadata.NewMem(cadata.DefaultMaxSize)
+	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := gdat.NewOperator()
 	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
 

--- a/pkg/gotnet/gotnet_test.go
+++ b/pkg/gotnet/gotnet_test.go
@@ -92,7 +92,7 @@ func newTestSide(t testing.TB, inetSrv inet256.Service, privKey p2p.PrivateKey) 
 		require.NoError(t, node.Close())
 	})
 	swarm := mbapp.New(inet256client.NewSwarm(node, privKey.Public()), MaxMessageSize)
-	newStore := func() cadata.Store { return cadata.NewMem(1 << 20) }
+	newStore := func() cadata.Store { return cadata.NewMem(cadata.DefaultHash, 1<<20) }
 	space := branches.NewMem(newStore, cells.NewMem)
 	srv := New(Params{
 		Space: space,

--- a/pkg/gotnet/store.go
+++ b/pkg/gotnet/store.go
@@ -419,7 +419,7 @@ func newTempStore() *tempStore {
 	return &tempStore{
 		handles: make(map[uint64]cadata.ID),
 		rcs:     make(map[cadata.ID]uint64),
-		store:   cadata.NewMem(maxBlobSize),
+		store:   cadata.NewMem(cadata.DefaultHash, maxBlobSize),
 	}
 }
 

--- a/pkg/gotrepo/cleanup.go
+++ b/pkg/gotrepo/cleanup.go
@@ -2,10 +2,10 @@ package gotrepo
 
 import (
 	"context"
-	"log"
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/gotvc/got/pkg/branches"
+	"github.com/sirupsen/logrus"
 )
 
 func (r *Repo) Cleanup(ctx context.Context) error {
@@ -24,10 +24,10 @@ func (r *Repo) CleanupBranch(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	log.Println("begin cleanup on", name)
+	logrus.Println("begin cleanup on", name)
 	if err := branches.CleanupVolume(ctx, branch.Volume); err != nil {
 		return err
 	}
-	log.Println("done cleanup on", name)
+	logrus.Println("done cleanup on", name)
 	return nil
 }

--- a/pkg/gotrepo/config.go
+++ b/pkg/gotrepo/config.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 )
 
 type Config struct {
@@ -18,8 +18,8 @@ func DefaultConfig() Config {
 	}
 }
 
-func LoadConfig(fsx fs.FS, p string) (*Config, error) {
-	data, err := fs.ReadFile(context.TODO(), fsx, p)
+func LoadConfig(fsx posixfs.FS, p string) (*Config, error) {
+	data, err := posixfs.ReadFile(context.TODO(), fsx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -30,10 +30,10 @@ func LoadConfig(fsx fs.FS, p string) (*Config, error) {
 	return config, nil
 }
 
-func SaveConfig(fsx fs.FS, p string, c Config) error {
+func SaveConfig(fsx posixfs.FS, p string, c Config) error {
 	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return err
 	}
-	return fs.PutFile(context.TODO(), fsx, p, 0o644, bytes.NewReader(data))
+	return posixfs.PutFile(context.TODO(), fsx, p, 0o644, bytes.NewReader(data))
 }

--- a/pkg/gotrepo/keys.go
+++ b/pkg/gotrepo/keys.go
@@ -10,7 +10,7 @@ import (
 	"io"
 
 	"github.com/brendoncarroll/go-p2p"
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/pkg/errors"
 )
 
@@ -26,26 +26,26 @@ func (r *Repo) GetPrivateKey() p2p.PrivateKey {
 	return r.privateKey
 }
 
-func LoadPrivateKey(fsx fs.FS, p string) (p2p.PrivateKey, error) {
-	data, err := fs.ReadFile(context.TODO(), fsx, p)
+func LoadPrivateKey(fsx posixfs.FS, p string) (p2p.PrivateKey, error) {
+	data, err := posixfs.ReadFile(context.TODO(), fsx, p)
 	if err != nil {
 		return nil, err
 	}
 	return parsePrivateKey(data)
 }
 
-func SavePrivateKey(fsx fs.FS, p string, privateKey p2p.PrivateKey) error {
+func SavePrivateKey(fsx posixfs.FS, p string, privateKey p2p.PrivateKey) error {
 	data := marshalPrivateKey(privateKey)
 	return writeIfNotExists(fsx, p, 0o600, bytes.NewReader(data))
 }
 
-func writeIfNotExists(fsx fs.FS, p string, mode fs.FileMode, r io.Reader) error {
-	f, err := fsx.OpenFile(p, fs.O_EXCL|fs.O_CREATE|fs.O_WRONLY, mode)
+func writeIfNotExists(fsx posixfs.FS, p string, mode posixfs.FileMode, r io.Reader) error {
+	f, err := fsx.OpenFile(p, posixfs.O_EXCL|posixfs.O_CREATE|posixfs.O_WRONLY, mode)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	if _, err := io.Copy(f.(fs.RegularFile), r); err != nil {
+	if _, err := io.Copy(f, r); err != nil {
 		return err
 	}
 	return f.Close()

--- a/pkg/gotrepo/repo.go
+++ b/pkg/gotrepo/repo.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/brendoncarroll/go-p2p"
 	"github.com/brendoncarroll/go-state/cadata"
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/gotvc/got/pkg/branches"
 	"github.com/gotvc/got/pkg/cells"
 	"github.com/gotvc/got/pkg/gdat"
@@ -54,7 +54,7 @@ const (
 )
 
 type (
-	FS = fs.FS
+	FS = posixfs.FS
 
 	Cell   = cells.Cell
 	Space  = branches.Space
@@ -90,8 +90,8 @@ type Repo struct {
 }
 
 func Init(p string) error {
-	repoDirFS := fs.NewDirFS(p)
-	if _, err := repoDirFS.Stat(configPath); fs.IsErrNotExist(err) {
+	repoDirFS := posixfs.NewDirFS(p)
+	if _, err := repoDirFS.Stat(configPath); posixfs.IsErrNotExist(err) {
 	} else if err != nil {
 		return err
 	} else {
@@ -126,7 +126,7 @@ func Init(p string) error {
 
 func Open(p string) (*Repo, error) {
 	ctx := context.TODO()
-	repoFS := fs.NewDirFS(p)
+	repoFS := posixfs.NewDirFS(p)
 	config, err := LoadConfig(repoFS, configPath)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func Open(p string) (*Repo, error) {
 		config:     *config,
 		privateKey: privateKey,
 		db:         db,
-		workingDir: fs.NewFiltered(repoFS, func(x string) bool {
+		workingDir: posixfs.NewFiltered(repoFS, func(x string) bool {
 			return !strings.HasPrefix(x, gotPrefix)
 		}),
 		tracker: newTracker(db, []string{bucketTracker}),
@@ -156,7 +156,7 @@ func Open(p string) (*Repo, error) {
 	r.storeManager = newStoreManager(fsStore, r.db, bucketStores)
 	r.cellManager = newCellManager(db, []string{bucketCellData})
 
-	r.specDir = newBranchSpecDir(r.makeDefaultVolume, r.MakeCell, r.MakeStore, fs.NewDirFS(filepath.Join(r.rootPath, specDirPath)))
+	r.specDir = newBranchSpecDir(r.makeDefaultVolume, r.MakeCell, r.MakeStore, posixfs.NewDirFS(filepath.Join(r.rootPath, specDirPath)))
 	if _, err := branches.CreateIfNotExists(ctx, r.specDir, nameMaster, branches.NewParams(false)); err != nil {
 		return nil, err
 	}
@@ -192,8 +192,8 @@ func (r *Repo) GetACL() *Policy {
 	return r.policy
 }
 
-func (r *Repo) getSubFS(prefix string) fs.FS {
-	return fs.NewPrefixed(r.repoFS, prefix)
+func (r *Repo) getSubFS(prefix string) posixfs.FS {
+	return posixfs.NewPrefixed(r.repoFS, prefix)
 }
 
 func (r *Repo) getFSOp(b *branches.Branch) *gotfs.Operator {

--- a/pkg/gotrepo/repo.go
+++ b/pkg/gotrepo/repo.go
@@ -131,7 +131,10 @@ func Open(p string) (*Repo, error) {
 	if err != nil {
 		return nil, err
 	}
-	db, err := bolt.Open(dbPath(p), 0o644, &bolt.Options{Timeout: time.Second})
+	db, err := bolt.Open(dbPath(p), 0o644, &bolt.Options{
+		Timeout: time.Second,
+		NoSync:  true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +174,7 @@ func Open(p string) (*Repo, error) {
 
 func (r *Repo) Close() (retErr error) {
 	for _, fn := range []func() error{
+		r.db.Sync,
 		r.db.Close,
 	} {
 		if err := fn(); retErr == nil {

--- a/pkg/gotrepo/repo_test.go
+++ b/pkg/gotrepo/repo_test.go
@@ -1,16 +1,20 @@
 package gotrepo
 
 import (
-	"bytes"
 	"context"
+	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
+	"math/rand"
+	"path"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/brendoncarroll/go-state/posixfs"
+	"github.com/gotvc/got/pkg/gotfs"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestRepoInit(t *testing.T) {
@@ -32,17 +36,12 @@ func TestRepoInit(t *testing.T) {
 func TestCommit(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	dirpath := t.TempDir()
-	t.Log("testing in", dirpath)
-	require.NoError(t, Init(dirpath))
-	repo, err := Open(dirpath)
-	require.NoError(t, err)
-	require.NotNil(t, repo)
-
+	repo := newTestRepo(t)
+	fs := repo.WorkingDir()
 	p := "test.txt"
 	p2 := "test2.txt"
 	fileContents := "file contents\n"
-	err = ioutil.WriteFile(filepath.Join(dirpath, p), []byte(fileContents), 0o644)
+	err := posixfs.PutFile(ctx, fs, p, 00644, strings.NewReader(fileContents))
 	require.NoError(t, err)
 	err = repo.Track(ctx, p)
 	require.NoError(t, err)
@@ -50,11 +49,11 @@ func TestCommit(t *testing.T) {
 	err = repo.Commit(ctx, SnapInfo{})
 	require.NoError(t, err)
 
-	checkFileContent(t, repo, p, fileContents)
+	checkFileContent(t, repo, p, strings.NewReader(fileContents))
 
 	// delete p, add p2
-	require.NoError(t, os.Remove(filepath.Join(dirpath, p)))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dirpath, p2), []byte(fileContents), 0o644))
+	require.NoError(t, posixfs.DeleteFile(ctx, fs, p))
+	require.NoError(t, posixfs.PutFile(ctx, fs, p2, 0o644, strings.NewReader(fileContents)))
 	// track both
 	require.NoError(t, repo.Track(ctx, p))
 	require.NoError(t, repo.Track(ctx, p2))
@@ -62,31 +61,120 @@ func TestCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	checkNotExists(t, repo, p)
-	checkFileContent(t, repo, p2, fileContents)
+	checkFileContent(t, repo, p2, strings.NewReader(fileContents))
 
 	require.NoError(t, repo.Check(ctx))
 }
 
+func TestCommitLargeFile(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := newTestRepo(t)
+	fs := repo.WorkingDir()
+
+	p := "largefile"
+	const size = 500e6
+	newReader := func() io.Reader {
+		rng := rand.New(rand.NewSource(0))
+		rand.New(rand.NewSource(0))
+		return io.LimitReader(rng, size)
+	}
+	require.NoError(t, posixfs.PutFile(ctx, fs, p, 0o644, newReader()))
+	require.NoError(t, repo.Track(ctx, p))
+	require.NoError(t, repo.Commit(ctx, SnapInfo{}))
+	checkExists(t, repo, p)
+	checkFileContent(t, repo, p, newReader())
+}
+
+func TestCommitDir(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := newTestRepo(t)
+	fs := repo.WorkingDir()
+
+	dirpath := "path/to/dir"
+	require.NoError(t, posixfs.MkdirAll(fs, dirpath, 0o755))
+	const N = 10
+	getPath := func(i int) string {
+		return path.Join(dirpath, strconv.Itoa(i))
+	}
+	getContent := func(i int) string {
+		return fmt.Sprintf("file data %016x", i)
+	}
+	for i := 0; i < N; i++ {
+		p := getPath(i)
+		content := getContent(i)
+		require.NoError(t, posixfs.PutFile(ctx, fs, p, 0o644, strings.NewReader(content)))
+	}
+	require.NoError(t, repo.Track(ctx, dirpath))
+	require.NoError(t, repo.Commit(ctx, SnapInfo{}))
+	for i := 0; i < N; i++ {
+		p := getPath(i)
+		content := getContent(i)
+		checkExists(t, repo, p)
+		checkFileContent(t, repo, p, strings.NewReader(content))
+	}
+}
+
 func newTestRepo(t testing.TB) *Repo {
 	dirpath := t.TempDir()
+	t.Log("testing in", dirpath)
 	require.NoError(t, Init(dirpath))
 	repo, err := Open(dirpath)
 	require.NoError(t, err)
+	require.NotNil(t, repo)
 	return repo
 }
 
-func checkFileContent(t testing.TB, repo *Repo, p, content string) {
+func checkFileContent(t testing.TB, repo *Repo, p string, r io.Reader) {
 	ctx := context.Background()
-	buf := bytes.Buffer{}
-	err := repo.Cat(ctx, p, &buf)
+	var expected, actual [32]byte
+	eg := errgroup.Group{}
+	eg.Go(func() error {
+		h, err := blake2b.New256(nil)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := io.Copy(h, r); err != nil {
+			return err
+		}
+		h.Sum(expected[:0])
+		return nil
+	})
+	eg.Go(func() error {
+		h, err := blake2b.New256(nil)
+		if err != nil {
+			panic(err)
+		}
+		if err := repo.Cat(ctx, p, h); err != nil {
+			return err
+		}
+		h.Sum(actual[:0])
+		return nil
+	})
+	require.NoError(t, eg.Wait())
+	require.Equal(t, expected, actual, "file %q content did not match", p)
+}
+
+func exists(t testing.TB, repo *Repo, p string) bool {
+	ctx := context.Background()
+	var found bool
+	err := repo.Ls(ctx, path.Dir(p), func(ent gotfs.DirEnt) error {
+		found = found || ent.Name == path.Base(p)
+		return nil
+	})
 	require.NoError(t, err)
-	require.Equal(t, content, buf.String())
+	return found
+}
+
+func checkExists(t testing.TB, repo *Repo, p string) {
+	t.Helper()
+	found := exists(t, repo, p)
+	require.True(t, found)
 }
 
 func checkNotExists(t testing.TB, repo *Repo, p string) {
-	ctx := context.Background()
-	err := repo.Cat(ctx, p, io.Discard)
-	if err != nil && !posixfs.IsErrNotExist(err) {
-		require.NoError(t, err)
-	}
+	t.Helper()
+	found := exists(t, repo, p)
+	require.False(t, found)
 }

--- a/pkg/gotrepo/repo_test.go
+++ b/pkg/gotrepo/repo_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,5 +86,7 @@ func checkFileContent(t testing.TB, repo *Repo, p, content string) {
 func checkNotExists(t testing.TB, repo *Repo, p string) {
 	ctx := context.Background()
 	err := repo.Cat(ctx, p, io.Discard)
-	require.True(t, os.IsNotExist(err))
+	if err != nil && !posixfs.IsErrNotExist(err) {
+		require.NoError(t, err)
+	}
 }

--- a/pkg/gotrepo/space.go
+++ b/pkg/gotrepo/space.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/brendoncarroll/go-state/cadata"
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/gotvc/got/pkg/branches"
 )
 
@@ -20,10 +20,10 @@ type branchSpecDir struct {
 	makeDefault func() VolumeSpec
 	cf          cellFactory
 	sf          storeFactory
-	fs          fs.FS
+	fs          posixfs.FS
 }
 
-func newBranchSpecDir(makeDefault func() VolumeSpec, cf cellFactory, sf storeFactory, fs fs.FS) *branchSpecDir {
+func newBranchSpecDir(makeDefault func() VolumeSpec, cf cellFactory, sf storeFactory, fs posixfs.FS) *branchSpecDir {
 	return &branchSpecDir{
 		makeDefault: makeDefault,
 		cf:          cf,
@@ -33,7 +33,7 @@ func newBranchSpecDir(makeDefault func() VolumeSpec, cf cellFactory, sf storeFac
 }
 
 func (r *branchSpecDir) ForEach(ctx context.Context, fn func(string) error) error {
-	return fs.WalkLeaves(ctx, r.fs, "", func(p string, _ fs.DirEnt) error {
+	return posixfs.WalkLeaves(ctx, r.fs, "", func(p string, _ posixfs.DirEnt) error {
 		return fn(p)
 	})
 }
@@ -69,9 +69,9 @@ func (r *branchSpecDir) Delete(ctx context.Context, k string) error {
 }
 
 func (r *branchSpecDir) Get(ctx context.Context, k string) (*Branch, error) {
-	data, err := fs.ReadFile(ctx, r.fs, k)
+	data, err := posixfs.ReadFile(ctx, r.fs, k)
 	if err != nil {
-		if fs.IsErrNotExist(err) {
+		if posixfs.IsErrNotExist(err) {
 			return nil, branches.ErrNotExist
 		}
 		return nil, err

--- a/pkg/gotrepo/staging.go
+++ b/pkg/gotrepo/staging.go
@@ -2,8 +2,8 @@ package gotrepo
 
 import (
 	"context"
-	"log"
 	"path"
+	"sort"
 	"time"
 
 	"github.com/brendoncarroll/go-state/cadata"
@@ -13,6 +13,7 @@ import (
 	"github.com/gotvc/got/pkg/gotvc"
 	"github.com/gotvc/got/pkg/porting"
 	"github.com/gotvc/got/pkg/stores"
+	"github.com/sirupsen/logrus"
 )
 
 // SnapInfo is additional information that can be attached to a snapshot
@@ -25,7 +26,7 @@ func (r *Repo) Commit(ctx context.Context, snapInfo SnapInfo) error {
 	if yes, err := r.tracker.IsEmpty(ctx); err != nil {
 		return err
 	} else if yes {
-		log.Println("WARN: nothing to commit")
+		logrus.Warn("nothing to commit")
 		return nil
 	}
 	_, branch, err := r.GetActiveBranch(ctx)
@@ -43,12 +44,12 @@ func (r *Repo) Commit(ctx context.Context, snapInfo SnapInfo) error {
 	fsop := r.getFSOp(branch)
 	err = branches.Apply(ctx, *branch, src, func(x *Snap) (*Snap, error) {
 		y, err := gotvc.Change(ctx, src.VC, x, func(root *Root) (*Root, error) {
-			log.Println("begin processing tracked paths")
+			logrus.Println("begin processing tracked paths")
 			nextRoot, err := r.applyTrackerChanges(ctx, fsop, src.FS, src.Raw, root)
 			if err != nil {
 				return nil, err
 			}
-			log.Println("done processing tracked paths")
+			logrus.Println("done processing tracked paths")
 			return nextRoot, nil
 		})
 		if err != nil {
@@ -83,39 +84,93 @@ func (r *Repo) StagingStore() cadata.Store {
 // applyTrackerChanges iterates through all the tracked paths and adds or deletes them from root
 // the new root, reflecting all of the changes indicated by the tracker, is returned.
 func (r *Repo) applyTrackerChanges(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, root *Root) (*Root, error) {
-	if root == nil {
+	ads := stores.NewAsyncStore(ds, 32)
+	porter := porting.NewPorter(fsop, r.workingDir, nil)
+	stage := newStage(fsop, ms, ads)
+	if err := r.tracker.ForEach(ctx, func(target string) error {
+		return stage.Add(ctx, porter, target)
+	}); err != nil {
+		return nil, err
+	}
+	root, err := stage.Apply(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+	if err := ads.Close(); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+type stage struct {
+	gotfs  *gotfs.Operator
+	ms, ds Store
+
+	changes map[string]gotfs.Root
+}
+
+func newStage(fsop *gotfs.Operator, ms, ds Store) *stage {
+	return &stage{
+		gotfs:   fsop,
+		ms:      ms,
+		ds:      ds,
+		changes: make(map[string]gotfs.Root),
+	}
+}
+
+func (s *stage) Add(ctx context.Context, porter porting.Porter, p string) error {
+	pathRoot, err := porter.ImportPath(ctx, s.ms, s.ds, p)
+	if err != nil {
+		return err
+	}
+	s.changes[p] = *pathRoot
+	return nil
+}
+
+func (s *stage) Rm(ctx context.Context, p string) error {
+	emptyRoot, err := s.gotfs.NewEmpty(ctx, s.ms)
+	if err != nil {
+		return err
+	}
+	s.changes[p] = *emptyRoot
+	return nil
+}
+
+func (s *stage) Apply(ctx context.Context, base *gotfs.Root) (*gotfs.Root, error) {
+	if base == nil {
 		var err error
-		root, err = fsop.NewEmpty(ctx, ms)
+		base, err = s.gotfs.NewEmpty(ctx, s.ms)
 		if err != nil {
 			return nil, err
 		}
 	}
-	var changes []gotfs.Segment
-	if err := r.tracker.ForEach(ctx, func(target string) error {
-		pathRoot, err := porting.ImportPath(ctx, fsop, ms, ds, r.workingDir, target)
-		if err != nil {
-			return err
-		}
-		if !gotfs.IsEmpty(*pathRoot) {
-			root, err = fsop.MkdirAll(ctx, ms, *root, path.Dir(target))
+	var segs []gotfs.Segment
+	for _, p := range sortedMapKeys(s.changes) {
+		pathRoot := s.changes[p]
+		if !gotfs.IsEmpty(pathRoot) {
+			var err error
+			base, err = s.gotfs.MkdirAll(ctx, s.ms, *base, path.Dir(p))
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
-		pathRoot, err = fsop.AddPrefix(ctx, ms, target, *pathRoot)
+		segRoot, err := s.gotfs.AddPrefix(ctx, s.ms, p, pathRoot)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		changes = append(changes, gotfs.Segment{
-			Root: *pathRoot,
-			Span: gotfs.SpanForPath(target),
+		segs = append(segs, gotfs.Segment{
+			Root: *segRoot,
+			Span: gotfs.SpanForPath(p),
 		})
-		return nil
-	}); err != nil {
+	}
+	segs = prepareChanges(*base, segs)
+	logrus.Println("splicing...")
+	root, err := s.gotfs.Splice(ctx, s.ms, s.ds, segs)
+	if err != nil {
 		return nil, err
 	}
-	segs := prepareChanges(*root, changes)
-	return fsop.Splice(ctx, ms, ds, segs)
+	logrus.Println("done splicing.")
+	return root, nil
 }
 
 // prepareChanges ensures that the segments represent the whole key space, using base to fill in any gaps.
@@ -123,12 +178,14 @@ func prepareChanges(base gotfs.Root, changes []gotfs.Segment) []gotfs.Segment {
 	var segs []gotfs.Segment
 	for i := range changes {
 		// create the span to reference the root, should be inbetween the two entries from segs
-		var span gotkv.Span
+		var baseSpan gotkv.Span
 		if i > 0 {
-			span.Start = segs[i-1].Span.End
+			baseSpan.Start = segs[len(segs)-1].Span.End
 		}
-		span.End = changes[i].Span.Start
-		segs = append(segs, gotfs.Segment{Root: base, Span: span})
+		baseSpan.End = changes[i].Span.Start
+		baseSeg := gotfs.Segment{Root: base, Span: baseSpan}
+
+		segs = append(segs, baseSeg)
 		segs = append(segs, changes[i])
 	}
 	if len(segs) > 0 {
@@ -143,69 +200,11 @@ func prepareChanges(base gotfs.Root, changes []gotfs.Segment) []gotfs.Segment {
 	return segs
 }
 
-// func (r *Repo) forEachLeaf(ctx context.Context, fsop *gotfs.Operator, ms Store, root *Root, target string, fn func(p string) error) error {
-// 	eg := errgroup.Group{}
-// 	inWorking := make(chan string)
-// 	inSnapshot := make(chan string)
-// 	eg.Go(func() error {
-// 		defer close(inWorking)
-// 		err := posixfs.WalkLeaves(ctx, r.workingDir, target, func(p string, _ posixfs.DirEnt) error {
-// 			inWorking <- p
-// 			return nil
-// 		})
-// 		if posixfs.IsErrNotExist(err) {
-// 			err = nil
-// 		}
-// 		return err
-// 	})
-// 	eg.Go(func() error {
-// 		defer close(inSnapshot)
-// 		if root == nil {
-// 			return nil
-// 		}
-// 		return fsop.ForEachFile(ctx, ms, *root, target, func(p string, _ *gotfs.Metadata) error {
-// 			inSnapshot <- p
-// 			return nil
-// 		})
-// 	})
-// 	eg.Go(func() error {
-// 		var p1, p2 *string
-// 		// while both are open
-// 		for {
-// 			if p1 == nil {
-// 				if p, open := <-inWorking; open {
-// 					p1 = &p
-// 				}
-// 			}
-// 			if p2 == nil {
-// 				if p, open := <-inSnapshot; open {
-// 					p2 = &p
-// 				}
-// 			}
-
-// 			var p string
-// 			switch {
-// 			case p1 != nil && p2 != nil:
-// 				if *p1 < *p2 {
-// 					p = *p1
-// 					p1 = nil
-// 				} else {
-// 					p = *p2
-// 					p2 = nil
-// 				}
-// 			case p1 != nil:
-// 				p = *p1
-// 				p1 = nil
-// 			case p2 != nil:
-// 				p = *p2
-// 				p2 = nil
-// 			default:
-// 				return nil
-// 			}
-// 			if err := fn(p); err != nil {
-// 				return err
-// 			}
-// 		}
-// 	})
-// 	return eg.Wait()
-// }
+func sortedMapKeys(x map[string]gotfs.Root) []string {
+	var keys []string
+	for k := range x {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/gotrepo/tracking.go
+++ b/pkg/gotrepo/tracking.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/gotvc/got/pkg/gotfs"
 	bolt "go.etcd.io/bbolt"
 )
@@ -158,9 +158,9 @@ func bucketFromTx(tx *bolt.Tx, path []string) (*bolt.Bucket, error) {
 	return b, nil
 }
 
-func exists(x fs.FS, p string) (bool, error) {
+func exists(x posixfs.FS, p string) (bool, error) {
 	_, err := x.Stat(p)
-	if fs.IsErrNotExist(err) {
+	if posixfs.IsErrNotExist(err) {
 		return false, nil
 	}
 	if err != nil {

--- a/pkg/gotrepo/tracking.go
+++ b/pkg/gotrepo/tracking.go
@@ -19,7 +19,7 @@ func (r *Repo) Untrack(ctx context.Context, p string) error {
 
 func (r *Repo) ForEachTracked(ctx context.Context, fn func(p string, isDelete bool) error) error {
 	return r.tracker.ForEach(ctx, func(p string) error {
-		exists, err := exists(r.workingDir, p)
+		exists, err := existsInFS(r.workingDir, p)
 		if err != nil {
 			return err
 		}
@@ -158,7 +158,7 @@ func bucketFromTx(tx *bolt.Tx, path []string) (*bolt.Bucket, error) {
 	return b, nil
 }
 
-func exists(x posixfs.FS, p string) (bool, error) {
+func existsInFS(x posixfs.FS, p string) (bool, error) {
 	_, err := x.Stat(p)
 	if posixfs.IsErrNotExist(err) {
 		return false, nil

--- a/pkg/gotvc/delta.go
+++ b/pkg/gotvc/delta.go
@@ -3,10 +3,10 @@ package gotvc
 import (
 	"context"
 	"io"
-	"log"
 
 	"github.com/gotvc/got/pkg/gotfs"
 	"github.com/gotvc/got/pkg/gotkv"
+	"github.com/sirupsen/logrus"
 )
 
 type Delta struct {
@@ -101,7 +101,7 @@ func ApplyDelta(ctx context.Context, s Store, base *Snapshot, delta Delta) (*Sna
 		if root == nil {
 			return &delta.Additions, nil
 		}
-		log.Println("begin applying deletions")
+		logrus.Println("begin applying deletions")
 		err := kvop.ForEach(ctx, s, delta.Deletions, gotkv.TotalSpan(), func(ent gotkv.Entry) error {
 			var err error
 			root, err = fsop.RemoveAll(ctx, s, *root, string(ent.Key))
@@ -110,14 +110,14 @@ func ApplyDelta(ctx context.Context, s Store, base *Snapshot, delta Delta) (*Sna
 		if err != nil {
 			return nil, err
 		}
-		log.Println("done applying deletions")
+		logrus.Println("done applying deletions")
 
-		log.Println("begin merging")
+		logrus.Println("begin merging")
 		root, err = kvop.Merge(ctx, s, base.Root, delta.Additions)
 		if err != nil {
 			return nil, err
 		}
-		log.Println("done merging")
+		logrus.Println("done merging")
 		return root, nil
 	})
 }

--- a/pkg/gotvc/snapshot.go
+++ b/pkg/gotvc/snapshot.go
@@ -3,13 +3,13 @@ package gotvc
 import (
 	"context"
 	"encoding/json"
-	"log"
 	"time"
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/gotvc/got/pkg/gdat"
 	"github.com/gotvc/got/pkg/gotfs"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type (
@@ -215,7 +215,7 @@ func Sync(ctx context.Context, dst, src cadata.Store, snap Snapshot, syncRoot fu
 
 // Check ensures that snapshot is valid.
 func Check(ctx context.Context, s cadata.Store, snap Snapshot, checkRoot func(gotfs.Root) error) error {
-	log.Printf("checking commit #%d", snap.N)
+	logrus.Infof("checking commit #%d", snap.N)
 	if err := checkRoot(snap.Root); err != nil {
 		return err
 	}

--- a/pkg/porting/cache.go
+++ b/pkg/porting/cache.go
@@ -1,0 +1,17 @@
+package porting
+
+import (
+	"time"
+
+	"github.com/gotvc/got/pkg/gotfs"
+)
+
+type Entry struct {
+	ModifiedAt time.Time
+	Root       gotfs.Root
+}
+
+type Cache interface {
+	Put(p string, ent Entry) error
+	Get(p string) (*Entry, error)
+}

--- a/pkg/porting/porter.go
+++ b/pkg/porting/porter.go
@@ -6,29 +6,46 @@ import (
 	"io"
 	"path"
 	"runtime"
+	"sort"
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/gotvc/got/pkg/gotfs"
 	"github.com/gotvc/got/pkg/gotkv"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
+type Porter struct {
+	gotfs   *gotfs.Operator
+	posixfs posixfs.FS
+	cache   Cache
+}
+
+func NewPorter(fsop *gotfs.Operator, pfs posixfs.FS, cache Cache) Porter {
+	return Porter{
+		cache:   cache,
+		gotfs:   fsop,
+		posixfs: pfs,
+	}
+}
+
 // ImportPath returns gotfs instance containing the content in fsx at p.
 // The content will be at the root of the filesystem.
-func ImportPath(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx posixfs.FS, p string) (*gotfs.Root, error) {
-	stat, err := fsx.Stat(p)
+func (pr *Porter) ImportPath(ctx context.Context, ms, ds cadata.Store, p string) (*gotfs.Root, error) {
+	logrus.Infof("importing path %q", p)
+	stat, err := pr.posixfs.Stat(p)
 	if err != nil && !posixfs.IsErrNotExist(err) {
 		return nil, err
 	} else if posixfs.IsErrNotExist(err) {
-		return fsop.NewEmpty(ctx, ms)
+		return pr.gotfs.NewEmpty(ctx, ms)
 	}
 	if !stat.Mode().IsDir() {
-		return ImportFile(ctx, fsop, ms, ds, fsx, p)
+		return pr.ImportFile(ctx, ms, ds, p)
 	}
 	var changes []gotfs.Segment
-	emptyDir, err := createEmptyDir(ctx, fsop, ms, ds)
+	emptyDir, err := createEmptyDir(ctx, pr.gotfs, ms, ds)
 	if err != nil {
 		return nil, err
 	}
@@ -36,31 +53,34 @@ func ImportPath(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, 
 		Root: *emptyDir,
 		Span: gotkv.TotalSpan(),
 	})
-	dirents, err := posixfs.ReadDir(fsx, p)
+	dirents, err := posixfs.ReadDir(pr.posixfs, p)
 	if err != nil {
 		return nil, err
 	}
+	sort.Slice(dirents, func(i, j int) bool {
+		return dirents[i].Name < dirents[j].Name
+	})
 	for _, dirent := range dirents {
 		p2 := path.Join(p, dirent.Name)
-		pathRoot, err := ImportPath(ctx, fsop, ms, ds, fsx, p2)
+		pathRoot, err := pr.ImportPath(ctx, ms, ds, p2)
 		if err != nil {
 			return nil, err
 		}
-		pathRoot, err = fsop.AddPrefix(ctx, ms, dirent.Name, *pathRoot)
+		pathRoot, err = pr.gotfs.AddPrefix(ctx, ms, dirent.Name, *pathRoot)
 		if err != nil {
 			return nil, err
 		}
 		changes = append(changes, gotfs.Segment{
 			Root: *pathRoot,
-			Span: gotfs.SpanForPath(p),
+			Span: gotfs.SpanForPath(dirent.Name),
 		})
 	}
-	return fsop.Splice(ctx, ms, ds, changes)
+	return pr.gotfs.Splice(ctx, ms, ds, changes)
 }
 
 // ImportFile returns a gotfs.Root with the content from the file in fsx at p.
-func ImportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx posixfs.FS, p string) (*gotfs.Root, error) {
-	stat, err := fsx.Stat(p)
+func (pr *Porter) ImportFile(ctx context.Context, ms, ds cadata.Store, p string) (*gotfs.Root, error) {
+	stat, err := pr.posixfs.Stat(p)
 	if err != nil {
 		return nil, err
 	}
@@ -72,15 +92,15 @@ func ImportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, 
 	sizeCutoff := 2 * gotfs.DefaultAverageBlobSizeData * numWorkers
 	// fast path for small files
 	if fileSize < int64(sizeCutoff) {
-		f, err := fsx.OpenFile(p, posixfs.O_RDONLY, 0)
+		f, err := pr.posixfs.OpenFile(p, posixfs.O_RDONLY, 0)
 		if err != nil {
 			return nil, err
 		}
 		defer f.Close()
-		return fsop.CreateFileRoot(ctx, ms, ds, f)
+		return pr.gotfs.CreateFileRoot(ctx, ms, ds, f)
 	}
 	// for large files use multiple workers
-	return importFileConcurrent(ctx, fsop, ms, ds, fsx, p, numWorkers)
+	return importFileConcurrent(ctx, pr.gotfs, ms, ds, pr.posixfs, p, numWorkers)
 }
 
 func importFileConcurrent(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx posixfs.FS, p string, numWorkers int) (*gotfs.Root, error) {
@@ -89,6 +109,7 @@ func importFileConcurrent(ctx context.Context, fsop *gotfs.Operator, ms, ds cada
 		return nil, err
 	}
 	fileSize := stat.Size()
+	logrus.WithFields(logrus.Fields{"path": p, "size": fileSize, "num_workers": numWorkers}).Info("importing file...")
 	eg := errgroup.Group{}
 	extSlices := make([][]*gotfs.Extent, numWorkers)
 	for i := 0; i < numWorkers; i++ {
@@ -100,8 +121,10 @@ func importFileConcurrent(ctx context.Context, fsop *gotfs.Operator, ms, ds cada
 				return err
 			}
 			defer f.Close()
-			if _, err := f.Seek(start, io.SeekStart); err != nil {
+			if n, err := f.Seek(start, io.SeekStart); err != nil {
 				return err
+			} else if n != start {
+				return errors.Errorf("file seeked to wrong place HAVE: %d WANT: %d", n, start)
 			}
 			r := io.LimitReader(f, end-start)
 			exts, err := fsop.CreateExtents(ctx, ds, r)
@@ -109,6 +132,7 @@ func importFileConcurrent(ctx context.Context, fsop *gotfs.Operator, ms, ds cada
 				return err
 			}
 			extSlices[i] = exts
+			logrus.WithFields(logrus.Fields{"worker": i, "ext_count": len(exts), "start": start, "end": end}).Info("worker done")
 			return nil
 		})
 	}
@@ -128,11 +152,14 @@ func divide(total int64, numWorkers int, workerIndex int) (start, end int64) {
 	if end > total {
 		end = total
 	}
+	if workerIndex == numWorkers-1 {
+		end = total
+	}
 	return start, end
 }
 
-func ExportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, root gotfs.Root, fsx posixfs.FS, p string) error {
-	md, err := fsop.GetMetadata(ctx, ms, root, p)
+func (pr *Porter) ExportFile(ctx context.Context, ms, ds cadata.Store, root gotfs.Root, p string) error {
+	md, err := pr.gotfs.GetMetadata(ctx, ms, root, p)
 	if err != nil {
 		return err
 	}
@@ -140,8 +167,8 @@ func ExportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, 
 	if !mode.IsRegular() {
 		return errors.Errorf("ExportFile called for non-regular file %q: %v", p, mode)
 	}
-	r := fsop.NewReader(ctx, ms, ds, root, p)
-	return posixfs.PutFile(ctx, fsx, p, mode, r)
+	r := pr.gotfs.NewReader(ctx, ms, ds, root, p)
+	return posixfs.PutFile(ctx, pr.posixfs, p, mode, r)
 }
 
 func createEmptyDir(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store) (*gotfs.Root, error) {

--- a/pkg/porting/porting.go
+++ b/pkg/porting/porting.go
@@ -3,14 +3,63 @@ package porting
 
 import (
 	"context"
+	"io"
+	"path"
+	"runtime"
 
 	"github.com/brendoncarroll/go-state/cadata"
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/gotvc/got/pkg/gotfs"
+	"github.com/gotvc/got/pkg/gotkv"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
-func ImportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx fs.FS, p string) (*gotfs.Root, error) {
+// ImportPath returns gotfs instance containing the content in fsx at p.
+// The content will be at the root of the filesystem.
+func ImportPath(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx posixfs.FS, p string) (*gotfs.Root, error) {
+	stat, err := fsx.Stat(p)
+	if err != nil && !posixfs.IsErrNotExist(err) {
+		return nil, err
+	} else if posixfs.IsErrNotExist(err) {
+		return fsop.NewEmpty(ctx, ms)
+	}
+	if !stat.Mode().IsDir() {
+		return ImportFile(ctx, fsop, ms, ds, fsx, p)
+	}
+	var changes []gotfs.Segment
+	emptyDir, err := createEmptyDir(ctx, fsop, ms, ds)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, gotfs.Segment{
+		Root: *emptyDir,
+		Span: gotkv.TotalSpan(),
+	})
+	dirents, err := posixfs.ReadDir(fsx, p)
+	if err != nil {
+		return nil, err
+	}
+	for _, dirent := range dirents {
+		p2 := path.Join(p, dirent.Name)
+		pathRoot, err := ImportPath(ctx, fsop, ms, ds, fsx, p2)
+		if err != nil {
+			return nil, err
+		}
+		pathRoot, err = fsop.AddPrefix(ctx, ms, dirent.Name, *pathRoot)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, gotfs.Segment{
+			Root: *pathRoot,
+			Span: gotfs.SpanForPath(p),
+		})
+	}
+	return fsop.Splice(ctx, ms, ds, changes)
+}
+
+// ImportFile returns a gotfs.Root with the content from the file in fsx at p.
+func ImportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx posixfs.FS, p string) (*gotfs.Root, error) {
 	stat, err := fsx.Stat(p)
 	if err != nil {
 		return nil, err
@@ -18,23 +67,87 @@ func ImportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, 
 	if !stat.Mode().IsRegular() {
 		return nil, errors.Errorf("ImportFile called for non-regular file at path %q", p)
 	}
-	f, err := fsx.OpenFile(p, fs.O_RDONLY, 0)
+	fileSize := stat.Size()
+	numWorkers := runtime.GOMAXPROCS(0)
+	sizeCutoff := 2 * gotfs.DefaultAverageBlobSizeData * numWorkers
+	// fast path for small files
+	if fileSize < int64(sizeCutoff) {
+		f, err := fsx.OpenFile(p, posixfs.O_RDONLY, 0)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		return fsop.CreateFileRoot(ctx, ms, ds, f)
+	}
+	// for large files use multiple workers
+	return importFileConcurrent(ctx, fsop, ms, ds, fsx, p, numWorkers)
+}
+
+func importFileConcurrent(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, fsx posixfs.FS, p string, numWorkers int) (*gotfs.Root, error) {
+	stat, err := fsx.Stat(p)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
-	return fsop.CreateFileRoot(ctx, ms, ds, f.(fs.RegularFile))
+	fileSize := stat.Size()
+	eg := errgroup.Group{}
+	extSlices := make([][]*gotfs.Extent, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		i := i
+		start, end := divide(fileSize, numWorkers, i)
+		eg.Go(func() error {
+			f, err := fsx.OpenFile(p, posixfs.O_RDONLY, 0)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if _, err := f.Seek(start, io.SeekStart); err != nil {
+				return err
+			}
+			r := io.LimitReader(f, end-start)
+			exts, err := fsop.CreateExtents(ctx, ds, r)
+			if err != nil {
+				return err
+			}
+			extSlices[i] = exts
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	var extents []*gotfs.Extent
+	for i := range extSlices {
+		extents = append(extents, extSlices[i]...)
+	}
+	return fsop.CreateFileRootFromExtents(ctx, ms, ds, extents)
 }
 
-func ExportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, root gotfs.Root, fsx fs.FS, p string) error {
+func divide(total int64, numWorkers int, workerIndex int) (start, end int64) {
+	start = (total / int64(numWorkers)) * int64(workerIndex)
+	end = (total / int64(numWorkers)) * int64(workerIndex+1)
+	if end > total {
+		end = total
+	}
+	return start, end
+}
+
+func ExportFile(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store, root gotfs.Root, fsx posixfs.FS, p string) error {
 	md, err := fsop.GetMetadata(ctx, ms, root, p)
 	if err != nil {
 		return err
 	}
-	mode := fs.FileMode(md.Mode)
+	mode := posixfs.FileMode(md.Mode)
 	if !mode.IsRegular() {
 		return errors.Errorf("ExportFile called for non-regular file %q: %v", p, mode)
 	}
 	r := fsop.NewReader(ctx, ms, ds, root, p)
-	return fs.PutFile(ctx, fsx, p, mode, r)
+	return posixfs.PutFile(ctx, fsx, p, mode, r)
+}
+
+func createEmptyDir(ctx context.Context, fsop *gotfs.Operator, ms, ds cadata.Store) (*gotfs.Root, error) {
+	empty, err := fsop.NewEmpty(ctx, ms)
+	if err != nil {
+		return nil, err
+	}
+	return fsop.Mkdir(ctx, ms, *empty, "")
 }

--- a/pkg/stores/stores.go
+++ b/pkg/stores/stores.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/brendoncarroll/go-state/cadata/fsstore"
-	"github.com/brendoncarroll/go-state/fs"
+	"github.com/brendoncarroll/go-state/posixfs"
 )
 
 type (
@@ -53,6 +53,6 @@ func (ms MemSet) List(ctx context.Context, first []byte, ids []cadata.ID) (int, 
 	return n, cadata.ErrEndOfList
 }
 
-func NewFSStore(x fs.FS, maxSize int) cadata.Store {
+func NewFSStore(x posixfs.FS, maxSize int) cadata.Store {
 	return fsstore.New(x, cadata.DefaultHash, maxSize)
 }


### PR DESCRIPTION
Improves import performance using `gotfs.Splice` and a concurrent file importer.

- Changes logging to use `logrus`
- Switch to RabinKarp for fingerprinting in `chunking.ContentDefined`
- Fix bug where `gotfs.MkdirAll` would not create the root
- `ptree.StreamWriter` uses the hash of entire entries to determine a split point.  It uses highwayhash for this.
- Remove `WriteNoSplit` method from chunkers.  It is no longer needed by `ptree`.
- Adds buffer pool to `store.AsyncStore`
- Adds package `porting` for imports/exports between gotfs and posixfs