### PR TITLE
KV Iterator API Change

### DIFF
--- a/pkg/gdat/crypto.go
+++ b/pkg/gdat/crypto.go
@@ -56,7 +56,9 @@ func Convergent(ptextHash cadata.ID) DEK {
 	return dek
 }
 
-type DEK [32]byte
+const DEKSize = 32
+
+type DEK [DEKSize]byte
 
 func (*DEK) String() string {
 	return "{ 32 byte DEK }"

--- a/pkg/gdat/refs.go
+++ b/pkg/gdat/refs.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const MaxRefBinaryLen = cadata.IDSize + DEKSize
+
 type Ref struct {
 	CID cadata.ID
 	DEK DEK

--- a/pkg/gotfs/files.go
+++ b/pkg/gotfs/files.go
@@ -103,7 +103,7 @@ func (o *Operator) ReadFileAt(ctx context.Context, ms, ds Store, x Root, p strin
 	for n < len(buf) {
 		n2, err := o.readFromIterator(ctx, it, ds, start, buf[n:])
 		if err != nil {
-			if err == io.EOF {
+			if err == gotkv.EOS {
 				break
 			}
 			return n, err
@@ -118,8 +118,8 @@ func (o *Operator) ReadFileAt(ctx context.Context, ms, ds Store, x Root, p strin
 }
 
 func (o *Operator) readFromIterator(ctx context.Context, it gotkv.Iterator, ds cadata.Store, start uint64, buf []byte) (int, error) {
-	ent, err := it.Next(ctx)
-	if err != nil {
+	var ent gotkv.Entry
+	if err := it.Next(ctx, &ent); err != nil {
 		return 0, err
 	}
 	_, extentEnd, err := splitExtentKey(ent.Key)

--- a/pkg/gotkv/keys.go
+++ b/pkg/gotkv/keys.go
@@ -1,8 +1,6 @@
 package gotkv
 
-import (
-	"github.com/gotvc/got/pkg/gotkv/ptree"
-)
+import "github.com/gotvc/got/pkg/gotkv/kv"
 
 // PrefixSpan returns a Span that includes all keys with prefix p
 func PrefixSpan(p []byte) Span {
@@ -31,13 +29,13 @@ func PrefixEnd(prefix []byte) []byte {
 }
 
 func KeyAfter(x []byte) []byte {
-	return ptree.KeyAfter(x)
+	return kv.KeyAfter(x)
 }
 
 func TotalSpan() Span {
-	return ptree.TotalSpan()
+	return kv.TotalSpan()
 }
 
 func SingleKeySpan(k []byte) Span {
-	return ptree.SingleItemSpan(k)
+	return kv.SingleItemSpan(k)
 }

--- a/pkg/gotkv/kv.go
+++ b/pkg/gotkv/kv.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/gotvc/got/pkg/gdat"
+	"github.com/gotvc/got/pkg/gotkv/kv"
 	"github.com/gotvc/got/pkg/gotkv/ptree"
 	"github.com/gotvc/got/pkg/stores"
 	"github.com/pkg/errors"
@@ -22,6 +23,7 @@ type (
 )
 
 var ErrKeyNotFound = errors.Errorf("key not found")
+var EOS = kv.EOS
 
 var defaultReadOnlyOperator = &Operator{dop: gdat.NewOperator()}
 

--- a/pkg/gotkv/kv/kv.go
+++ b/pkg/gotkv/kv/kv.go
@@ -1,0 +1,87 @@
+package kv
+
+import (
+	"bytes"
+	"context"
+	goerrors "errors"
+	"fmt"
+)
+
+// Entry is a single entry in a stream/tree
+type Entry struct {
+	Key, Value []byte
+}
+
+// Clone makes a copy of Entry where Key and Value do not point to memory overlapping with the original
+func (e Entry) Clone() Entry {
+	return Entry{
+		Key:   append([]byte{}, e.Key...),
+		Value: append([]byte{}, e.Value...),
+	}
+}
+
+// EOS signals the end of a stream
+var EOS = goerrors.New("end of stream")
+
+type Iterator interface {
+	Next(ctx context.Context, ent *Entry) error
+	Seek(ctx context.Context, gteq []byte) error
+	Peek(ctx context.Context, ent *Entry) error
+}
+
+// A span of keys [Start, End)
+// If you want to include a specific end key, use the KeyAfter function.
+// nil is interpretted as no bound, not as a 0 length key.  This behaviour is only releveant for End.
+type Span struct {
+	Start, End []byte
+}
+
+func (s Span) String() string {
+	return fmt.Sprintf("[%q, %q)", s.Start, s.End)
+}
+
+func TotalSpan() Span {
+	return Span{}
+}
+
+func SingleItemSpan(x []byte) Span {
+	return Span{
+		Start: x,
+		End:   KeyAfter(x),
+	}
+}
+
+// LessThan returns true if every key in the Span is below key
+func (s Span) LessThan(key []byte) bool {
+	return s.End != nil && bytes.Compare(s.End, key) <= 0
+}
+
+// GreaterThan returns true if every key in the span is greater than k
+func (s Span) GreaterThan(k []byte) bool {
+	return s.Start != nil && bytes.Compare(s.Start, k) > 0
+}
+
+func (s Span) Contains(k []byte) bool {
+	return !s.GreaterThan(k) && !s.LessThan(k)
+}
+
+func (s Span) Clone() Span {
+	var start, end []byte
+	if s.Start != nil {
+		start = append([]byte{}, s.Start...)
+	}
+	if s.End != nil {
+		end = append([]byte{}, s.End...)
+	}
+	return Span{
+		Start: start,
+		End:   end,
+	}
+}
+
+// KeyAfter returns the key immediately after x.
+// There will be no key less than the result and greater than x
+func KeyAfter(x []byte) []byte {
+	y := append([]byte{}, x...)
+	return append(y, 0x00)
+}

--- a/pkg/gotkv/ptree/kv.go
+++ b/pkg/gotkv/ptree/kv.go
@@ -18,7 +18,7 @@ type (
 
 func MaxKey(ctx context.Context, s cadata.Store, x Root, under []byte) ([]byte, error) {
 	op := gdat.NewOperator()
-	sr := NewStreamReader(s, &op, rootToIndex(x))
+	sr := NewStreamReader(s, &op, []Index{rootToIndex(x)})
 	ent, err := maxEntry(ctx, sr, under)
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func DebugTree(s cadata.Store, x Root) {
 			indent += "  "
 		}
 		ctx := context.TODO()
-		sr := NewStreamReader(s, &op, Index{Ref: x.Ref, First: x.First})
+		sr := NewStreamReader(s, &op, []Index{{Ref: x.Ref, First: x.First}})
 		fmt.Printf("%sTREE NODE: %s %d\n", indent, x.Ref.CID.String(), x.Depth)
 		if x.Depth == 0 {
 			for {

--- a/pkg/gotkv/ptree/kv_test.go
+++ b/pkg/gotkv/ptree/kv_test.go
@@ -34,9 +34,10 @@ func TestAddPrefix(t *testing.T) {
 	t.Logf("produced %d blobs", s.Len())
 
 	it := NewIterator(s, &op, *root, Span{})
+	var ent Entry
 	for i := 0; i < N; i++ {
-		ent, err := it.Next(ctx)
+		err := it.Next(ctx, &ent)
 		require.NoError(t, err, "at %d", i)
-		require.True(t, bytes.HasPrefix(ent.Key, prefix))
+		require.True(t, bytes.HasPrefix(ent.Key, prefix), "at %d: %q does not have prefix %q", i, ent.Key, prefix)
 	}
 }

--- a/pkg/gotkv/ptree/mutate.go
+++ b/pkg/gotkv/ptree/mutate.go
@@ -42,7 +42,7 @@ func mutate(ctx context.Context, b *Builder, idx Index, depth int, mut Mutation)
 // index at depth d has references to d - 1, where 0 is data.
 func mutateTree(ctx context.Context, b *Builder, idx Index, depth int, mut Mutation) error {
 	fnCalled := false
-	sr := NewStreamReader(b.s, b.op, idx)
+	sr := NewStreamReader(b.s, b.op, []Index{idx})
 	var ent Entry
 	for {
 		if err := sr.Next(ctx, &ent); err != nil {
@@ -88,7 +88,7 @@ func mutateEntries(ctx context.Context, b *Builder, target Index, mut Mutation) 
 		fnCalled = true
 		return mut.Fn(ent)
 	}
-	sr := NewStreamReader(b.s, b.op, target)
+	sr := NewStreamReader(b.s, b.op, []Index{target})
 	var inEnt Entry
 	for {
 		if err := sr.Next(ctx, &inEnt); err != nil {
@@ -131,7 +131,7 @@ func copyTree(ctx context.Context, b *Builder, depth int, idx Index) error {
 		return copyEntries(ctx, b, idx)
 	}
 
-	sr := NewStreamReader(b.s, b.op, idx)
+	sr := NewStreamReader(b.s, b.op, []Index{idx})
 	var ent Entry
 	for {
 		if err := sr.Next(ctx, &ent); err != nil {
@@ -153,7 +153,7 @@ func copyTree(ctx context.Context, b *Builder, depth int, idx Index) error {
 
 // copyEntries resolves index (which should be depth=1), and writes each entry to b
 func copyEntries(ctx context.Context, b *Builder, idx Index) error {
-	sr := NewStreamReader(b.s, b.op, idx)
+	sr := NewStreamReader(b.s, b.op, []Index{idx})
 	var ent Entry
 	for {
 		if err := sr.Next(ctx, &ent); err != nil {

--- a/pkg/gotkv/ptree/mutate.go
+++ b/pkg/gotkv/ptree/mutate.go
@@ -2,9 +2,9 @@ package ptree
 
 import (
 	"context"
-	"io"
 
 	"github.com/gotvc/got/pkg/gdat"
+	"github.com/gotvc/got/pkg/gotkv/kv"
 )
 
 // Mutate applies the mutation mut, to the tree root.
@@ -43,15 +43,15 @@ func mutate(ctx context.Context, b *Builder, idx Index, depth int, mut Mutation)
 func mutateTree(ctx context.Context, b *Builder, idx Index, depth int, mut Mutation) error {
 	fnCalled := false
 	sr := NewStreamReader(b.s, b.op, idx)
+	var ent Entry
 	for {
-		ent, err := sr.Next(ctx)
-		if err != nil {
-			if err == io.EOF {
+		if err := sr.Next(ctx, &ent); err != nil {
+			if err == kv.EOS {
 				break
 			}
 			return err
 		}
-		idx2, err := entryToIndex(*ent)
+		idx2, err := entryToIndex(ent)
 		if err != nil {
 			return err
 		}
@@ -63,8 +63,8 @@ func mutateTree(ctx context.Context, b *Builder, idx Index, depth int, mut Mutat
 			continue
 		}
 		// at this point the first entry must be <= the span
-		ent2, err := sr.Peek(ctx)
-		if err != nil && err != io.EOF {
+		var ent2 Entry
+		if err := sr.Peek(ctx, &ent2); err != nil && err != kv.EOS {
 			return err
 		}
 		if err == nil && mut.Span.GreaterThan(ent2.Key) {
@@ -89,10 +89,10 @@ func mutateEntries(ctx context.Context, b *Builder, target Index, mut Mutation) 
 		return mut.Fn(ent)
 	}
 	sr := NewStreamReader(b.s, b.op, target)
+	var inEnt Entry
 	for {
-		inEnt, err := sr.Next(ctx)
-		if err != nil {
-			if err == io.EOF {
+		if err := sr.Next(ctx, &inEnt); err != nil {
+			if err == kv.EOS {
 				err = nil
 			}
 			return err
@@ -106,7 +106,7 @@ func mutateEntries(ctx context.Context, b *Builder, target Index, mut Mutation) 
 			}
 		}
 		if mut.Span.Contains(inEnt.Key) {
-			outEnts := fn(inEnt)
+			outEnts := fn(&inEnt)
 			for _, outEnt := range outEnts {
 				if err := b.Put(ctx, outEnt.Key, outEnt.Value); err != nil {
 					return err
@@ -132,15 +132,15 @@ func copyTree(ctx context.Context, b *Builder, depth int, idx Index) error {
 	}
 
 	sr := NewStreamReader(b.s, b.op, idx)
+	var ent Entry
 	for {
-		ent, err := sr.Next(ctx)
-		if err != nil {
-			if err == io.EOF {
+		if err := sr.Next(ctx, &ent); err != nil {
+			if err == kv.EOS {
 				break
 			}
 			return err
 		}
-		idx2, err := entryToIndex(*ent)
+		idx2, err := entryToIndex(ent)
 		if err != nil {
 			return err
 		}
@@ -154,10 +154,10 @@ func copyTree(ctx context.Context, b *Builder, depth int, idx Index) error {
 // copyEntries resolves index (which should be depth=1), and writes each entry to b
 func copyEntries(ctx context.Context, b *Builder, idx Index) error {
 	sr := NewStreamReader(b.s, b.op, idx)
+	var ent Entry
 	for {
-		ent, err := sr.Next(ctx)
-		if err != nil {
-			if err == io.EOF {
+		if err := sr.Next(ctx, &ent); err != nil {
+			if err == kv.EOS {
 				break
 			}
 			return err
@@ -189,7 +189,10 @@ func entryToIndex(ent Entry) (Index, error) {
 	if err != nil {
 		return Index{}, err
 	}
-	return Index{First: ent.Key, Ref: *ref}, nil
+	return Index{
+		First: append([]byte{}, ent.Key...),
+		Ref:   *ref,
+	}, nil
 }
 
 func indexToRoot(idx Index, depth uint8) Root {

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -239,7 +239,7 @@ func (it *Iterator) setPosAfter(k []byte) {
 }
 
 func peekEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index, gteq []byte, ent *Entry) error {
-	sr := NewStreamReader(s, op, idx)
+	sr := NewStreamReader(s, op, []Index{idx})
 	if err := sr.Seek(ctx, gteq); err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func ListChildren(ctx context.Context, s cadata.Store, op *gdat.Operator, root R
 	if root.Depth < 1 {
 		return nil, errors.Errorf("cannot list children of root with depth=%d", root.Depth)
 	}
-	sr := NewStreamReader(s, op, rootToIndex(root))
+	sr := NewStreamReader(s, op, []Index{rootToIndex(root)})
 	var idxs []Index
 	var ent Entry
 	for {
@@ -321,7 +321,7 @@ func ListChildren(ctx context.Context, s cadata.Store, op *gdat.Operator, root R
 // ListEntries
 func ListEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index) ([]Entry, error) {
 	var ents []Entry
-	sr := NewStreamReader(s, op, idx)
+	sr := NewStreamReader(s, op, []Index{idx})
 	for {
 		var ent Entry
 		if err := sr.Next(ctx, &ent); err != nil {
@@ -332,4 +332,18 @@ func ListEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Ind
 		}
 		ents = append(ents, ent)
 	}
+}
+
+type indexReader struct {
+	sr *StreamReader
+}
+
+func newIndexReader(ctx context.Context, s cadata.Store, op *gdat.Operator, idxs []Index) *indexReader {
+	return &indexReader{
+		sr: NewStreamReader(s, op, idxs),
+	}
+}
+
+func (r *indexReader) Next(ctx context.Context, idx Index) error {
+	return nil
 }

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -333,17 +333,3 @@ func ListEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Ind
 		ents = append(ents, ent)
 	}
 }
-
-type indexReader struct {
-	sr *StreamReader
-}
-
-func newIndexReader(ctx context.Context, s cadata.Store, op *gdat.Operator, idxs []Index) *indexReader {
-	return &indexReader{
-		sr: NewStreamReader(s, op, idxs),
-	}
-}
-
-func (r *indexReader) Next(ctx context.Context, idx Index) error {
-	return nil
-}

--- a/pkg/gotkv/ptree/stream.go
+++ b/pkg/gotkv/ptree/stream.go
@@ -223,14 +223,12 @@ func (w *StreamWriter) Append(ctx context.Context, ent Entry) error {
 	if entryLen > w.maxSize {
 		return errors.Errorf("entry (size=%d) exceeds maximum size %d", entryLen, w.maxSize)
 	}
-	//log.Printf("append key=%q prevKey=%q firstKey=%q isFirst=%t entryLen=%d buf=%d", ent.Key, w.prevKey, w.firstKey, w.firstKey == nil, entryLen, w.Buffered())
 	if entryLen+w.buf.Len() > w.maxSize {
 		if err := w.Flush(ctx); err != nil {
 			return err
 		}
 	}
 
-	// TODO: remove this and just write to the underlying buffer
 	offset := w.buf.Len()
 	if w.firstKey == nil {
 		if w.buf.Len() > 0 {

--- a/pkg/gotkv/ptree/stream_test.go
+++ b/pkg/gotkv/ptree/stream_test.go
@@ -55,18 +55,10 @@ func TestStreamRW(t *testing.T) {
 	err := sw.Flush(ctx)
 	require.NoError(t, err)
 
-	var sr = NewStreamReader(s, &op, idxs[0])
-	idxs = idxs[1:]
+	sr := NewStreamReader(s, &op, idxs)
 	var ent Entry
 	for i := 0; i < N; i++ {
-		var err error
-		if err = sr.Next(ctx, &ent); err == kv.EOS {
-			idx := idxs[0]
-			idxs = idxs[1:]
-			sr = NewStreamReader(s, &op, idx)
-			i--
-			continue
-		}
+		err := sr.Next(ctx, &ent)
 		require.NoError(t, err)
 		require.Equal(t, string(keyFromInt(i)), string(ent.Key))
 	}


### PR DESCRIPTION
Changes the methods used for key-value entry iteration to take a `*Entry`.  The entry will be overwritten by the next entry in the iteration.  The buffers for the key and value are reused, to avoid allocating memory.

- Adds `gotkv/kv` package, which contains some of the code that was shared between `ptree` and `gotkv`
- `gotkv/kv`: `EOS` "end of stream" error for signaling the end of kv iteration.