### PR TITLE
Prevent rolling hash zero value from producing min size chunks

### DIFF
--- a/pkg/chunking/api.go
+++ b/pkg/chunking/api.go
@@ -4,9 +4,6 @@ package chunking
 type Chunker interface {
 	// Write writes bytes to the chunker, chunks can be produced anywhere in the slice
 	Write(p []byte) (int, error)
-	// WriteNoSplit writes the buffer and guarentees it will not be split into multiple chunks
-	// whether the data goes into the current chunk or into the next is up to the implementation.
-	WriteNoSplit([]byte) error
 	// Buffered returns the number of bytes buffered, but not yet made into a chunk.
 	Buffered() int
 	// Flush forces the production of a chunk, if there is any buffered data.

--- a/pkg/chunking/chunker_test.go
+++ b/pkg/chunking/chunker_test.go
@@ -9,42 +9,76 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChunker(t *testing.T) {
+func TestContentDefined(t *testing.T) {
 	t.Parallel()
-	const N = 1e7
-	avgSize := 1 << 13
-	maxSize := 1 << 20
+	const (
+		N       = 1e7
+		avgSize = 1 << 13
+		maxSize = 1 << 20
+	)
 
-	var count int
-	var size int
-	poly := DerivePolynomial(nil)
-	c := NewContentDefined(64, avgSize, maxSize, poly, func(data []byte) error {
+	t.Run("Random", func(t *testing.T) {
+		t.Parallel()
+		r := io.LimitReader(randReader{}, N)
+		count, size := testChunker(t, func(ch ChunkHandler) Chunker {
+			poly := DerivePolynomial(nil)
+			return NewContentDefined(64, avgSize, maxSize, poly, ch)
+		}, r, maxSize)
+		// average size should be close to what we expect
+		t.Log("size:", size, "count:", count, "avg:", size/count)
+		withinTolerance(t, size/count, avgSize, 0.05)
+		// all the data should have been chunked
+		require.Equal(t, int(N), size)
+	})
+
+	t.Run("Zero", func(t *testing.T) {
+		t.Parallel()
+		r := io.LimitReader(zeroReader{}, N)
+		count, size := testChunker(t, func(ch ChunkHandler) Chunker {
+			poly := DerivePolynomial(nil)
+			return NewContentDefined(64, avgSize, maxSize, poly, ch)
+		}, r, maxSize)
+		// average size should be much bigger than min size
+		t.Log("size:", size, "count:", count, "avg:", size/count)
+		require.Greater(t, size/count, 64*100)
+
+		// all the data should have been chunked
+		require.Equal(t, int(N), size)
+
+	})
+}
+
+func testChunker(t *testing.T, newChunker func(func(data []byte) error) Chunker, r io.Reader, maxSize int) (count, size int) {
+	c := newChunker(func(data []byte) error {
 		count++
 		size += len(data)
 		require.LessOrEqual(t, len(data), maxSize)
 		return nil
 	})
 	// copy in some data
-	_, err := io.Copy(c, io.LimitReader(randReader{}, N))
+	_, err := io.Copy(c, r)
 	require.NoError(t, err)
 	// close
 	require.NoError(t, c.Flush())
-
-	// average size should be close to what we expect
-	t.Log("size:", size, "count:", count, "avg:", size/count)
-	withinTolerance(t, size/count, avgSize, 0.05)
-
-	// all the data should have been chunked
-	require.Equal(t, int(N), size)
+	return count, size
 }
 
 func withinTolerance(t *testing.T, x int, target int, tol float64) {
 	ok := math.Abs(float64(x)-float64(target)) < float64(target)*tol
-	require.True(t, ok)
+	require.True(t, ok, "%d not within +/- %f of target %d", x, tol, target)
 }
 
 type randReader struct{}
 
 func (r randReader) Read(p []byte) (n int, err error) {
 	return mrand.Read(p)
+}
+
+type zeroReader struct{ c byte }
+
+func (r zeroReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		p[i] = r.c
+	}
+	return len(p), nil
 }

--- a/pkg/gotfs/operator.go
+++ b/pkg/gotfs/operator.go
@@ -260,6 +260,9 @@ func Dump(ctx context.Context, s Store, root Root, w io.Writer) error {
 	it := op.gotkv.NewIterator(s, root, gotkv.TotalSpan())
 	var ent gotkv.Entry
 	for err := it.Next(ctx, &ent); err != gotkv.EOS; err = it.Next(ctx, &ent) {
+		if err != nil {
+			return err
+		}
 		switch {
 		case isExtentKey(ent.Key):
 			ext, err := parseExtent(ent.Value)


### PR DESCRIPTION
Previously, a run of the same byte would produce min sized chunks.  A constant is xor'd with the hash sum to prevent that.  now runs of the same byte will never be a chunk point.