### PR TITLE
`ptree.Iterator` Improvements

### DIFF
--- a/pkg/gotkv/kvstreams/kv.go
+++ b/pkg/gotkv/kvstreams/kv.go
@@ -106,11 +106,3 @@ func KeyAfter(x []byte) []byte {
 	y := append([]byte{}, x...)
 	return append(y, 0x00)
 }
-
-// Mutation represents a mutation to the stream
-// if there is nothing in the Span, Fn will be called once with nil
-// otherwise Fn will be called once for every item in the Span.
-type Mutation struct {
-	Span Span
-	Fn   func(*Entry) []Entry
-}

--- a/pkg/gotkv/kvstreams/kv.go
+++ b/pkg/gotkv/kvstreams/kv.go
@@ -29,6 +29,14 @@ type Iterator interface {
 	Peek(ctx context.Context, ent *Entry) error
 }
 
+func Peek(ctx context.Context, it Iterator) (*Entry, error) {
+	var ent Entry
+	if err := it.Peek(ctx, &ent); err != nil {
+		return nil, err
+	}
+	return &ent, nil
+}
+
 func ForEach(ctx context.Context, it Iterator, fn func(ent Entry) error) error {
 	var ent Entry
 	for err := it.Next(ctx, &ent); err != EOS; err = it.Next(ctx, &ent) {

--- a/pkg/gotkv/kvstreams/kv.go
+++ b/pkg/gotkv/kvstreams/kv.go
@@ -106,3 +106,11 @@ func KeyAfter(x []byte) []byte {
 	y := append([]byte{}, x...)
 	return append(y, 0x00)
 }
+
+// Mutation represents a mutation to the stream
+// if there is nothing in the Span, Fn will be called once with nil
+// otherwise Fn will be called once for every item in the Span.
+type Mutation struct {
+	Span Span
+	Fn   func(*Entry) []Entry
+}

--- a/pkg/gotkv/ptree/mutate.go
+++ b/pkg/gotkv/ptree/mutate.go
@@ -7,6 +7,14 @@ import (
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 )
 
+// Mutation represents a mutation to the stream
+// if there is nothing in the Span, Fn will be called once with nil
+// otherwise Fn will be called once for every item in the Span.
+type Mutation struct {
+	Span Span
+	Fn   func(*Entry) []Entry
+}
+
 // Mutate applies the mutation mut, to the tree root.
 func Mutate(ctx context.Context, b *Builder, root Root, mut Mutation) (*Root, error) {
 	fnCalled := false
@@ -167,14 +175,6 @@ func copyEntries(ctx context.Context, b *Builder, idx Index) error {
 		}
 	}
 	return nil
-}
-
-// Mutation represents a mutation to the tree
-// if there is nothing in the Span, Fn will be called once with nil
-// otherwise Fn will be called once for every item in the Span.
-type Mutation struct {
-	Span Span
-	Fn   func(*Entry) []Entry
 }
 
 func indexToEntry(idx Index) Entry {

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -237,6 +237,10 @@ func (it *Iterator) Seek(ctx context.Context, gteq []byte) error {
 	return it.initRoot(ctx)
 }
 
+func (it *Iterator) syncedAt(i int) bool {
+	return it.srs[i] == nil
+}
+
 func (it *Iterator) withReader(ctx context.Context, i int, fn func(sr *StreamReader) error) error {
 	for {
 		sr, err := it.getReader(ctx, i)

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -237,10 +237,6 @@ func (it *Iterator) Seek(ctx context.Context, gteq []byte) error {
 	return it.initRoot(ctx)
 }
 
-func (it *Iterator) syncedAt(i int) bool {
-	return it.srs[i] == nil
-}
-
 func (it *Iterator) withReader(ctx context.Context, i int, fn func(sr *StreamReader) error) error {
 	for {
 		sr, err := it.getReader(ctx, i)

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -188,6 +188,7 @@ type Iterator struct {
 	op   *gdat.Operator
 	root Root
 	span Span
+	srs  []*StreamReader
 	pos  []byte
 }
 
@@ -197,88 +198,173 @@ func NewIterator(s cadata.Store, op *gdat.Operator, root Root, span Span) *Itera
 		op:   op,
 		root: root,
 		span: span.Clone(),
+		srs:  make([]*StreamReader, root.Depth+1),
 	}
-	it.pos = it.span.Start
+	it.setPos(span.Start)
 	return it
 }
 
 func (it *Iterator) Next(ctx context.Context, ent *Entry) error {
-	if err := it.Peek(ctx, ent); err != nil {
+	if err := it.initRoot(ctx); err != nil {
+		return err
+	}
+	if err := it.withReader(ctx, 0, func(sr *StreamReader) error {
+		return sr.Next(ctx, ent)
+	}); err != nil {
 		return err
 	}
 	it.setPosAfter(ent.Key)
-	return nil
+	return it.checkAfterSpan(ent)
 }
 
 func (it *Iterator) Peek(ctx context.Context, ent *Entry) error {
-	if _, err := it.peek(ctx, ent); err != nil {
+	if err := it.initRoot(ctx); err != nil {
 		return err
 	}
+	if err := it.withReader(ctx, 0, func(sr *StreamReader) error {
+		return sr.Peek(ctx, ent)
+	}); err != nil {
+		return err
+	}
+	return it.checkAfterSpan(ent)
+}
+
+func (it *Iterator) Seek(ctx context.Context, gteq []byte) error {
+	it.setPos(gteq)
+	for i := range it.srs {
+		it.srs[i] = nil
+	}
+	return it.initRoot(ctx)
+}
+
+func (it *Iterator) withReader(ctx context.Context, i int, fn func(sr *StreamReader) error) error {
+	for {
+		sr, err := it.getReader(ctx, i)
+		if err != nil {
+			return err
+		}
+		if err := fn(sr); err != nil {
+			if err == kvstreams.EOS {
+				it.srs[i] = nil
+				continue
+			}
+			return err
+		} else {
+			return nil
+		}
+	}
+}
+
+func (it *Iterator) getReader(ctx context.Context, i int) (*StreamReader, error) {
+	if i >= len(it.srs) {
+		return nil, kvstreams.EOS
+	}
+	if it.srs[i] != nil {
+		return it.srs[i], nil
+	}
+	if err := it.withReader(ctx, i+1, func(srAbove *StreamReader) error {
+		idxs, err := readIndexes(ctx, srAbove)
+		if err != nil {
+			return err
+		}
+		it.srs[i+1] = nil
+		it.srs[i] = NewStreamReader(it.s, it.op, idxs)
+		// TODO: seeking does not work on the higher levels
+		if i == 0 {
+			return it.srs[i].Seek(ctx, it.pos)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return it.srs[i], nil
+}
+
+func (it *Iterator) checkAfterSpan(ent *Entry) error {
 	if it.span.LessThan(ent.Key) {
 		return kvstreams.EOS
 	}
 	return nil
 }
 
-func (it *Iterator) peek(ctx context.Context, ent *Entry) (int, error) {
-	return peekTree(ctx, it.s, it.op, it.root, it.pos, ent)
+func (it *Iterator) setPos(x []byte) {
+	it.pos = append(it.pos[:0], x...)
 }
 
-func (it *Iterator) Seek(ctx context.Context, k []byte) error {
-	it.setPos(k)
-	return nil
-}
-
-func (it *Iterator) setPos(k []byte) {
-	it.pos = append(it.pos[:0], k...)
-}
-
-func (it *Iterator) setPosAfter(k []byte) {
-	it.setPos(k)
+func (it *Iterator) setPosAfter(x []byte) {
+	it.setPos(x)
 	it.pos = append(it.pos, 0x00)
 }
 
-func peekEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index, gteq []byte, ent *Entry) error {
-	sr := NewStreamReader(s, op, []Index{idx})
-	if err := sr.Seek(ctx, gteq); err != nil {
-		return err
+func (it *Iterator) initRoot(ctx context.Context) error {
+	i := len(it.srs) - 1
+	if it.srs[i] != nil {
+		return nil
 	}
-	return sr.Next(ctx, ent)
+	it.srs[i] = NewStreamReader(it.s, it.op, []Index{rootToIndex(it.root)})
+	// TODO: seeking does not work on the higher levels
+	if i == 0 {
+		return it.srs[i].Seek(ctx, it.pos)
+	}
+	return nil
 }
 
-func peekTree(ctx context.Context, s cadata.Store, op *gdat.Operator, root Root, gteq []byte, ent *Entry) (int, error) {
-	if root.Depth == 0 {
-		idx := rootToIndex(root)
-		if err := peekEntries(ctx, s, op, idx, gteq, ent); err != nil {
-			return 0, err
-		}
-		var syncLevel int
-		if bytes.Equal(ent.Key, idx.First) {
-			syncLevel = 1
-		}
-		return syncLevel, nil
-	} else {
-		idxs, err := ListChildren(ctx, s, op, root)
+func readIndexes(ctx context.Context, it kvstreams.Iterator) ([]Index, error) {
+	var idxs []Index
+	if err := kvstreams.ForEach(ctx, it, func(ent Entry) error {
+		idx, err := entryToIndex(ent)
 		if err != nil {
-			return 0, err
+			return err
 		}
-		for i := 0; i < len(idxs); i++ {
-			// if the first element in the next is also lteq then skip.
-			if i+1 < len(idxs) && bytes.Compare(idxs[i+1].First, gteq) <= 0 {
-				continue
-			}
-			syncLevel, err := peekTree(ctx, s, op, indexToRoot(idxs[i], root.Depth-1), gteq, ent)
-			if err == kvstreams.EOS {
-				continue
-			}
-			if i == 0 {
-				syncLevel++
-			}
-			return syncLevel, err
-		}
-		return 0, kvstreams.EOS
+		idxs = append(idxs, idx)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
+	return idxs, nil
 }
+
+// func peekEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index, gteq []byte, ent *Entry) error {
+// 	sr := NewStreamReader(s, op, []Index{idx})
+// 	if err := sr.Seek(ctx, gteq); err != nil {
+// 		return err
+// 	}
+// 	return sr.Next(ctx, ent)
+// }
+
+// func peekTree(ctx context.Context, s cadata.Store, op *gdat.Operator, root Root, gteq []byte, ent *Entry) (int, error) {
+// 	if root.Depth == 0 {
+// 		idx := rootToIndex(root)
+// 		if err := peekEntries(ctx, s, op, idx, gteq, ent); err != nil {
+// 			return 0, err
+// 		}
+// 		var syncLevel int
+// 		if bytes.Equal(ent.Key, idx.First) {
+// 			syncLevel = 1
+// 		}
+// 		return syncLevel, nil
+// 	} else {
+// 		idxs, err := ListChildren(ctx, s, op, root)
+// 		if err != nil {
+// 			return 0, err
+// 		}
+// 		for i := 0; i < len(idxs); i++ {
+// 			// if the first element in the next is also lteq then skip.
+// 			if i+1 < len(idxs) && bytes.Compare(idxs[i+1].First, gteq) <= 0 {
+// 				continue
+// 			}
+// 			syncLevel, err := peekTree(ctx, s, op, indexToRoot(idxs[i], root.Depth-1), gteq, ent)
+// 			if err == kvstreams.EOS {
+// 				continue
+// 			}
+// 			if i == 0 {
+// 				syncLevel++
+// 			}
+// 			return syncLevel, err
+// 		}
+// 		return 0, kvstreams.EOS
+// 	}
+// }
 
 // CopyAll copies all the entries from it to b.
 func CopyAll(ctx context.Context, b *Builder, it *Iterator) error {

--- a/pkg/gotkv/ptree/ptree_test.go
+++ b/pkg/gotkv/ptree/ptree_test.go
@@ -101,5 +101,5 @@ func TestMutate(t *testing.T) {
 		}
 	})
 	err = it.Next(ctx, &ent)
-	require.Equal(t, err, kvstreams.EOS)
+	require.Equal(t, kvstreams.EOS, err)
 }

--- a/pkg/gotkv/ptree/stream.go
+++ b/pkg/gotkv/ptree/stream.go
@@ -38,9 +38,6 @@ func newBlobReader(firstKey []byte, data []byte) blobReader {
 }
 
 func (r *blobReader) Seek(ctx context.Context, gteq []byte) error {
-	if bytes.Compare(gteq, r.prevKey) < 0 {
-		r.prevKey = append(r.prevKey[:0], r.firstKey...)
-	}
 	var ent Entry
 	for {
 		if err := r.Peek(ctx, &ent); err != nil {
@@ -125,9 +122,12 @@ func (r *StreamReader) Peek(ctx context.Context, ent *Entry) error {
 }
 
 func (r *StreamReader) Seek(ctx context.Context, gteq []byte) error {
+	if len(r.idxs) < 1 {
+		return nil
+	}
 	var targetIndex int
 	for i := 1; i < len(r.idxs); i++ {
-		if bytes.Compare(r.idxs[i].First, gteq) < 0 {
+		if bytes.Compare(r.idxs[i].First, gteq) <= 0 {
 			targetIndex = i
 		} else {
 			break


### PR DESCRIPTION
The `ptree.Iterator` inefficiently seeks through every blob for every entry instead of holding a position in the blob between entries.  The `ptree.StreamReader` is implemented this way.  Changes the `ptree.Iterator` to be implemented in terms of the `ptree.StreamReader`

Produces a ~6x improvement in `got debug fs` which runs in O(n) where n is the number of entries for extents and metadata.
```
BEFORE
got debug fs >> /dev/null  1.93s user 0.16s system 120% cpu 1.729 total
got debug fs >> /dev/null  1.94s user 0.16s system 120% cpu 1.743 total

AFTER
got debug fs >> /dev/null  0.29s user 0.04s system 123% cpu 0.264 total
got debug fs >> /dev/null  0.30s user 0.04s system 219% cpu 0.154 total
```