### PR TITLE
Snapshots can have multiple parents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/brendoncarroll/go-p2p v0.0.0-20211024183131-c0c41d099b71
-	github.com/brendoncarroll/go-state v0.0.0-20210925160250-39541eea7883
+	github.com/brendoncarroll/go-state v0.0.0-20211120152832-f56522ee55f4
 	github.com/chmduquesne/rollinghash v0.0.0-20180912150627-a60f8e7142b5
 	github.com/fatih/color v1.13.0
 	github.com/golang/protobuf v1.5.2
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.0
+	github.com/vektra/tai64n v0.0.0-20180410233929-12133dfe3281
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/brendoncarroll/go-p2p v0.0.0-20211024183131-c0c41d099b71 h1:2RehssELLWw6135cG/LnxkK4yX8k5SJ+vDn5kq+D/XQ=
 github.com/brendoncarroll/go-p2p v0.0.0-20211024183131-c0c41d099b71/go.mod h1:IYW1gZ9twSWJrkAil9jLMtHnVlAJ0wVc9Y5WpNlv9Oc=
 github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040/go.mod h1:EQKdXJyc93dh3yN1wRYdKjAZk+MutF5DFwoW+Vqe5U0=
-github.com/brendoncarroll/go-state v0.0.0-20210925160250-39541eea7883 h1:LhffiqQ3xfTZCPgDkZ2oXg+PGvFBF/zGFtUTRnw+d4M=
-github.com/brendoncarroll/go-state v0.0.0-20210925160250-39541eea7883/go.mod h1:M86VCqKTis4CJcSvWCoB1OZHuRu3d1c05iS7+6HbBQI=
+github.com/brendoncarroll/go-state v0.0.0-20211120152832-f56522ee55f4 h1:lfClEYWOHHRfbGDahkfgtvgpVNlE+TzhYU9a0Ewj9qI=
+github.com/brendoncarroll/go-state v0.0.0-20211120152832-f56522ee55f4/go.mod h1:RLj/N8MmYCrBuPRKizRhmee7fyyKo7ew/MdKv+oPdb8=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
@@ -53,6 +53,7 @@ github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIu
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
@@ -219,6 +220,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/vektra/tai64n v0.0.0-20180410233929-12133dfe3281 h1:yJi7DJKOdVIKR/FqZkp786GctUu786svqWtCnCWD9Mk=
+github.com/vektra/tai64n v0.0.0-20180410233929-12133dfe3281/go.mod h1:B0SuGiMlM79QVKut5/urroa7W9gGa6IeQ3Cz2yLPSe8=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/branches/branch.go
+++ b/pkg/branches/branch.go
@@ -76,5 +76,5 @@ func History(ctx context.Context, b Branch, vcop *gotvc.Operator, fn func(ref gd
 	if err := fn(ref, *snap); err != nil {
 		return err
 	}
-	return gotvc.ForEach(ctx, b.Volume.VCStore, *snap.Parent, fn)
+	return gotvc.ForEach(ctx, b.Volume.VCStore, snap.Parents, fn)
 }

--- a/pkg/gotcmd/commit.go
+++ b/pkg/gotcmd/commit.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/gotvc/got"
+	"github.com/gotvc/got/pkg/tai64"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -24,10 +24,11 @@ var commitCmd = &cobra.Command{
 	PostRunE: closeRepo,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// TODO get message from -m flag
-		now := time.Now()
+		now := tai64.Now()
 		return repo.Commit(ctx, got.SnapInfo{
-			Message:   "",
-			CreatedAt: &now,
+			Message:    "",
+			CreatedAt:  now,
+			AuthoredAt: now,
 		})
 	},
 }

--- a/pkg/gotcmd/status.go
+++ b/pkg/gotcmd/status.go
@@ -28,7 +28,7 @@ var statusCmd = &cobra.Command{
 		bufw := bufio.NewWriter(cmd.OutOrStdout())
 		fmt.Fprintf(bufw, "ACTIVE: %s\n", name)
 		fmt.Fprintf(bufw, "STAGING:\n")
-		if err := repo.ForEachStaging(ctx, func(p string, op gotrepo.Operation) error {
+		if err := repo.ForEachStaging(ctx, func(p string, op gotrepo.FileOperation) error {
 			var desc = "UNKNOWN"
 			switch {
 			case op.Delete:

--- a/pkg/gotnet/store.go
+++ b/pkg/gotnet/store.go
@@ -484,6 +484,9 @@ func (s *store) Get(ctx context.Context, id cadata.ID, buf []byte) (int, error) 
 }
 
 func (s *store) Post(ctx context.Context, data []byte) (cadata.ID, error) {
+	if len(data) > s.MaxSize() {
+		return cadata.ID{}, cadata.ErrTooLarge
+	}
 	id, x := s.blobPullSrv.store.Hold(data)
 	defer s.blobPullSrv.store.Release(x)
 	return id, s.blobMainSrv.PushTo(ctx, s.sid, []cadata.ID{id})

--- a/pkg/gotvc/gotvc.go
+++ b/pkg/gotvc/gotvc.go
@@ -1,6 +1,7 @@
 package gotvc
 
 import (
+	"container/list"
 	"context"
 
 	"github.com/brendoncarroll/go-state/cadata"
@@ -8,57 +9,109 @@ import (
 	"github.com/gotvc/got/pkg/stores"
 )
 
-// ForEach calls fn once for each ancestor of the snap at ref, and the snap at ref itself
-func ForEach(ctx context.Context, s cadata.Store, x Ref, fn func(Ref, Snapshot) error) error {
+// ForEach calls fn once for each Ref in the snapshot graph.
+func ForEach(ctx context.Context, s cadata.Store, xs []Ref, fn func(Ref, Snapshot) error) error {
 	o := NewOperator()
 	o.readOnly = true
-	for ref := &x; ref != nil; {
-		snap, err := o.GetSnapshot(ctx, s, *ref)
+	visited := map[Ref]struct{}{}
+	refs := newRefQueue()
+	refs.push(xs...)
+	for refs.len() > 0 {
+		ref := refs.pop()
+		snap, err := o.GetSnapshot(ctx, s, ref)
 		if err != nil {
 			return err
 		}
-		if err := fn(*ref, *snap); err != nil {
+		if err := fn(ref, *snap); err != nil {
 			return err
 		}
-		ref = snap.Parent
+		visited[ref] = struct{}{}
+		for _, parentRef := range snap.Parents {
+			if _, exists := visited[parentRef]; !exists {
+				refs.push(parentRef)
+			}
+		}
 	}
 	return nil
 }
 
+type refQueue struct {
+	list *list.List
+}
+
+func newRefQueue() *refQueue {
+	rq := &refQueue{
+		list: list.New(),
+	}
+	return rq
+}
+
+func (rq *refQueue) push(xs ...Ref) {
+	for _, x := range xs {
+		rq.list.PushBack(x)
+	}
+}
+
+func (rq *refQueue) pop() Ref {
+	el := rq.list.Front()
+	ret := el.Value.(Ref)
+	rq.list.Remove(el)
+	return ret
+}
+
+func (rq *refQueue) len() int {
+	return rq.list.Len()
+}
+
 // IsDescendentOf returns true if any of x's parents are equal to a.
 func IsDescendentOf(ctx context.Context, s Store, x, a Snapshot) (bool, error) {
+	m := map[Ref]struct{}{}
+	return isDescendentOf(ctx, m, s, x, a)
+}
+
+func isDescendentOf(ctx context.Context, m map[Ref]struct{}, s Store, x, a Snapshot) (bool, error) {
 	op := NewOperator()
 	op.readOnly = true
-	if x.Parent == nil {
-		return false, nil
+	for _, parentRef := range x.Parents {
+		if _, exists := m[parentRef]; exists {
+			continue
+		}
+		parent, err := op.GetSnapshot(ctx, s, parentRef)
+		if err != nil {
+			return false, err
+		}
+		if parent.Equals(a) {
+			return true, nil
+		}
+		yes, err := IsDescendentOf(ctx, s, *parent, a)
+		if err != nil {
+			return false, err
+		}
+		if yes {
+			return true, nil
+		}
+		m[parentRef] = struct{}{}
 	}
-	parent, err := op.GetSnapshot(ctx, s, *x.Parent)
-	if err != nil {
-		return false, err
-	}
-	if parent.Equals(a) {
-		return true, nil
-	}
-	return IsDescendentOf(ctx, s, *parent, a)
+	return false, nil
 }
 
 // Sync ensures dst has all of the data reachable from snap.
 func Sync(ctx context.Context, dst, src cadata.Store, snap Snapshot, syncRoot func(gotfs.Root) error) error {
 	op := NewOperator()
 	op.readOnly = true
-	if snap.Parent != nil {
-		// Skip if the parent is already copied.
-		if exists, err := dst.Exists(ctx, snap.Parent.CID); err != nil {
+	for _, parentRef := range snap.Parents {
+		// Skip if the parent is already copieda.
+		if exists, err := dst.Exists(ctx, parentRef.CID); err != nil {
 			return err
 		} else if !exists {
-			parent, err := op.GetSnapshot(ctx, src, *snap.Parent)
+			parent, err := op.GetSnapshot(ctx, src, parentRef)
 			if err != nil {
 				return err
 			}
 			if err := Sync(ctx, dst, src, *parent, syncRoot); err != nil {
 				return err
 			}
-			if err := cadata.Copy(ctx, dst, src, snap.Parent.CID); err != nil {
+			if err := cadata.Copy(ctx, dst, src, parentRef.CID); err != nil {
 				return err
 			}
 		}
@@ -69,14 +122,14 @@ func Sync(ctx context.Context, dst, src cadata.Store, snap Snapshot, syncRoot fu
 // Populate adds all the cadata.IDs reachable from start to set.
 // This will not include the CID for start itself, which has not yet been computed.
 func Populate(ctx context.Context, s cadata.Store, start Snapshot, set stores.Set, rootFn func(gotfs.Root) error) error {
-	if start.Parent != nil {
-		parentCID := start.Parent.CID
+	for _, parentRef := range start.Parents {
+		parentCID := parentRef.CID
 		exists, err := set.Exists(ctx, parentCID)
 		if err != nil {
 			return err
 		} else if !exists {
 			op := NewOperator()
-			parent, err := op.GetSnapshot(ctx, s, *start.Parent)
+			parent, err := op.GetSnapshot(ctx, s, parentRef)
 			if err != nil {
 				return err
 			}

--- a/pkg/tai64/timestamp.go
+++ b/pkg/tai64/timestamp.go
@@ -1,0 +1,45 @@
+package tai64
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/vektra/tai64n"
+)
+
+// TAI64 is a TAI64 timestamp
+type TAI64 uint64
+
+func Now() TAI64 {
+	return TAI64FromGoTime(time.Now())
+}
+
+func TAI64FromGoTime(x time.Time) TAI64 {
+	return TAI64(tai64n.FromTime(x).Seconds)
+}
+
+func (t TAI64) GoTime() time.Time {
+	t2 := tai64n.TAI64N{Seconds: uint64(t)}
+	return t2.Time()
+}
+
+func (t TAI64) String() string {
+	return t.GoTime().Local().String()
+}
+
+// ExternalFormat returns the "External TAI64 format"
+// as defined by https://cr.yp.to/libtai/tai64.html
+func (t TAI64) ExternalFormat() (ret [8]byte) {
+	binary.BigEndian.PutUint64(ret[:], uint64(t))
+	return ret
+}
+
+type TAI64N struct {
+	TAI64
+	Nanoseconds uint32
+}
+
+type TAI64NA struct {
+	TAI64N
+	Attoseconds uint32
+}


### PR DESCRIPTION
- Replaces Snapshot `Parent` field with `Parents`.
- Adds `AuthoredAt` field to Snapshots.
- Switches timestamps to TAI64.
- Bumps go-state and fixes failing cadata.Store test.