### PR TITLE
ptree: index copying

### DIFF
--- a/pkg/gotkv/kvstreams/kv.go
+++ b/pkg/gotkv/kvstreams/kv.go
@@ -62,6 +62,17 @@ func ForEach(ctx context.Context, it Iterator, fn func(ent Entry) error) error {
 	return nil
 }
 
+func Collect(ctx context.Context, it Iterator) ([]Entry, error) {
+	var ents []Entry
+	if err := ForEach(ctx, it, func(ent Entry) error {
+		ents = append(ents, ent.Clone())
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return ents, nil
+}
+
 // A span of keys [Start, End)
 // If you want to include a specific end key, use the KeyAfter function.
 // nil is interpretted as no bound, not as a 0 length key.  This behaviour is only releveant for End.

--- a/pkg/gotkv/ptree/iterator.go
+++ b/pkg/gotkv/ptree/iterator.go
@@ -3,7 +3,6 @@ package ptree
 import (
 	"bytes"
 	"context"
-	"log"
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/gotvc/got/pkg/gdat"
@@ -29,7 +28,6 @@ func NewIterator(s cadata.Store, op *gdat.Operator, root Root, span Span) *Itera
 		span:   span.Clone(),
 		levels: make([][]Entry, root.Depth+2),
 	}
-	log.Println("NewIterator span:", it.span)
 	it.levels[root.Depth+1] = []Entry{indexToEntry(rootToIndex(root))}
 	it.setPos(span.Start)
 	return it
@@ -112,7 +110,6 @@ func (it *Iterator) getEntries(ctx context.Context, level int) ([]Entry, error) 
 			ents = filterIndexes(ents, it.getSpan())
 		}
 		if len(ents) > 0 {
-			log.Println("filling level", level, len(ents))
 			it.levels[level] = ents
 			return it.levels[level], nil
 		}
@@ -132,7 +129,7 @@ func (it *Iterator) syncLevel() int {
 	// top is required because indexes at the right most side of the tree cannot be copied
 	// since they could point to incomplete nodes.
 	var top int
-	for i := len(it.levels) - 1; i > 0; i-- {
+	for i := len(it.levels) - 1; i >= 0; i-- {
 		top = i
 		if len(it.levels[i]) > 1 && bytes.Compare(it.levels[i][1].Key, it.span.End) < 0 {
 			break
@@ -185,7 +182,7 @@ func filterIndexes(xs []Entry, span Span) []Entry {
 		if span.LessThan(xs[i].Key) {
 			continue
 		}
-		if i+1 < len(xs) && span.GreaterThan(xs[i+1].Key) {
+		if i+1 < len(xs) && bytes.Compare(span.Start, xs[i+1].Key) >= 0 {
 			continue
 		}
 		ret = append(ret, xs[i])

--- a/pkg/gotkv/ptree/iterator.go
+++ b/pkg/gotkv/ptree/iterator.go
@@ -52,12 +52,26 @@ func (it *Iterator) next(ctx context.Context, level int, ent *Entry) error {
 }
 
 func (it *Iterator) syncLevel() int {
+	// TODO: can't copy indexes for artificially short entries
+	// tests occasionally fail because of duplicate keys
+	var bot int
 	for i := range it.srs {
+		bot = i
 		if it.srs[i] != nil {
-			return i
+			break
 		}
 	}
-	return len(it.srs) - 1
+	var top int
+	for i := len(it.srs) - 1; i > 0; i-- {
+		top = i
+		if it.srs[i] != nil {
+			sr := it.srs[i]
+			if sr.nextIndex < len(sr.idxs) {
+				break
+			}
+		}
+	}
+	return min(bot, top)
 }
 
 func (it *Iterator) Peek(ctx context.Context, ent *Entry) error {

--- a/pkg/gotkv/ptree/iterator.go
+++ b/pkg/gotkv/ptree/iterator.go
@@ -3,6 +3,7 @@ package ptree
 import (
 	"bytes"
 	"context"
+	"log"
 
 	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/gotvc/got/pkg/gdat"
@@ -15,18 +16,21 @@ type Iterator struct {
 	op   *gdat.Operator
 	root Root
 	span Span
-	srs  []*StreamReader
-	pos  []byte
+
+	levels [][]Entry
+	pos    []byte
 }
 
 func NewIterator(s cadata.Store, op *gdat.Operator, root Root, span Span) *Iterator {
 	it := &Iterator{
-		s:    s,
-		op:   op,
-		root: root,
-		span: span.Clone(),
-		srs:  make([]*StreamReader, root.Depth+1),
+		s:      s,
+		op:     op,
+		root:   root,
+		span:   span.Clone(),
+		levels: make([][]Entry, root.Depth+2),
 	}
+	log.Println("NewIterator span:", it.span)
+	it.levels[root.Depth+1] = []Entry{indexToEntry(rootToIndex(root))}
 	it.setPos(span.Start)
 	return it
 }
@@ -35,162 +39,156 @@ func (it *Iterator) Next(ctx context.Context, ent *Entry) error {
 	return it.next(ctx, 0, ent)
 }
 
-func (it *Iterator) next(ctx context.Context, level int, ent *Entry) error {
-	if err := it.initRoot(ctx); err != nil {
-		return err
+func (it *Iterator) Peek(ctx context.Context, ent *Entry) error {
+	return it.peek(ctx, 0, ent)
+}
+
+func (it *Iterator) Seek(ctx context.Context, gteq []byte) error {
+	it.levels[it.root.Depth+1] = []Entry{indexToEntry(rootToIndex(it.root))}
+	it.setPos(gteq)
+	for i := len(it.levels) - 1; i >= 0; i-- {
+		if i == 0 {
+			it.levels[i] = filterEntries(it.levels[i], it.getSpan())
+		} else {
+			it.levels[i] = filterIndexes(it.levels[i], it.getSpan())
+		}
 	}
+	return nil
+}
+
+func (it *Iterator) next(ctx context.Context, level int, ent *Entry) error {
 	if it.syncLevel() < level {
 		return errors.Errorf("cannot read from level %d, only synced to %d", level, it.syncLevel())
 	}
-	if err := it.withReader(ctx, level, func(sr *StreamReader) error {
-		return sr.Next(ctx, ent)
-	}); err != nil {
+	entries, err := it.getEntries(ctx, level)
+	if err != nil {
 		return err
 	}
-	it.setPosAfter(ent.Key)
-	return it.checkAfterSpan(ent)
+	ent2 := entries[0]
+	ent.Key = append(ent.Key[:0], ent2.Key...)
+	ent.Value = append(ent.Value[:0], ent2.Value...)
+	it.advanceLevel(level, true)
+	return nil
+}
+
+func (it *Iterator) peek(ctx context.Context, level int, ent *Entry) error {
+	if it.syncLevel() < level {
+		return errors.Errorf("cannot read from level %d, only synced to %d", level, it.syncLevel())
+	}
+	entries, err := it.getEntries(ctx, level)
+	if err != nil {
+		return err
+	}
+	ent2 := entries[0]
+	ent.Key = append(ent.Key[:0], ent2.Key...)
+	ent.Value = append(ent.Value[:0], ent2.Value...)
+	return nil
+}
+
+func (it *Iterator) getEntries(ctx context.Context, level int) ([]Entry, error) {
+	if level >= len(it.levels) {
+		return nil, kvstreams.EOS
+	}
+	if len(it.levels[level]) > 0 {
+		return it.levels[level], nil
+	}
+	for {
+		above, err := it.getEntries(ctx, level+1)
+		if err != nil {
+			return nil, err
+		}
+		idx, err := entryToIndex(above[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "converting entry to index at level %d", level)
+		}
+		it.advanceLevel(level+1, false)
+		ents, err := ListEntries(ctx, it.s, it.op, idx)
+		if err != nil {
+			return nil, err
+		}
+		if level == 0 {
+			ents = filterEntries(ents, it.getSpan())
+		} else {
+			ents = filterIndexes(ents, it.getSpan())
+		}
+		if len(ents) > 0 {
+			log.Println("filling level", level, len(ents))
+			it.levels[level] = ents
+			return it.levels[level], nil
+		}
+	}
 }
 
 func (it *Iterator) syncLevel() int {
-	// TODO: can't copy indexes for artificially short entries
-	// tests occasionally fail because of duplicate keys
+	// bot is the index below which all levels are synced
 	var bot int
-	for i := range it.srs {
+	for i := range it.levels {
 		bot = i
-		if it.srs[i] != nil {
+		if len(it.levels[i]) > 0 {
 			break
 		}
 	}
+	// top is maximum index where the level has more than 1 entry
+	// top is required because indexes at the right most side of the tree cannot be copied
+	// since they could point to incomplete nodes.
 	var top int
-	for i := len(it.srs) - 1; i > 0; i-- {
+	for i := len(it.levels) - 1; i > 0; i-- {
 		top = i
-		if it.srs[i] != nil {
-			sr := it.srs[i]
-			if sr.nextIndex < len(sr.idxs) {
-				break
-			}
+		if len(it.levels[i]) > 1 && bytes.Compare(it.levels[i][1].Key, it.span.End) < 0 {
+			break
 		}
 	}
 	return min(bot, top)
 }
 
-func (it *Iterator) Peek(ctx context.Context, ent *Entry) error {
-	if err := it.initRoot(ctx); err != nil {
-		return err
+func (it *Iterator) advanceLevel(level int, updatePos bool) {
+	entries := it.levels[level]
+	it.levels[level] = entries[1:]
+	if !updatePos {
+		return
 	}
-	if err := it.withReader(ctx, 0, func(sr *StreamReader) error {
-		return sr.Peek(ctx, ent)
-	}); err != nil {
-		return err
-	}
-	return it.checkAfterSpan(ent)
-}
-
-func (it *Iterator) Seek(ctx context.Context, gteq []byte) error {
-	it.setPos(gteq)
-	for i := range it.srs {
-		it.srs[i] = nil
-	}
-	return it.initRoot(ctx)
-}
-
-func (it *Iterator) withReader(ctx context.Context, i int, fn func(sr *StreamReader) error) error {
-	for {
-		sr, err := it.getReader(ctx, i)
-		if err != nil {
-			return err
-		}
-		if err := fn(sr); err != nil {
-			if err == kvstreams.EOS {
-				it.srs[i] = nil
-				continue
-			}
-			return err
-		} else {
-			return nil
+	for i := level; i < len(it.levels); i++ {
+		entries := it.levels[i]
+		if len(entries) > 0 {
+			it.setPos(entries[0].Key)
+			return
 		}
 	}
-}
-
-func (it *Iterator) getReader(ctx context.Context, i int) (*StreamReader, error) {
-	if i >= len(it.srs) {
-		return nil, kvstreams.EOS
-	}
-	if it.srs[i] != nil {
-		return it.srs[i], nil
-	}
-	if err := it.withReader(ctx, i+1, func(srAbove *StreamReader) error {
-		idxs, err := readIndexes(ctx, srAbove)
-		if err != nil {
-			return err
-		}
-		it.srs[i+1] = nil
-		it.srs[i] = NewStreamReader(it.s, it.op, idxs)
-		if i == 0 {
-			return it.srs[i].Seek(ctx, it.pos)
-		} else {
-			return it.srs[i].SeekIndexes(ctx, it.pos)
-		}
-	}); err != nil {
-		return nil, err
-	}
-	return it.srs[i], nil
-}
-
-// checkAfterSpan returns EOS if the entry is outside the iterators span.
-func (it *Iterator) checkAfterSpan(ent *Entry) error {
-	if it.span.LessThan(ent.Key) {
-		return kvstreams.EOS
-	}
-	return nil
+	it.pos = nil // end of the stream
 }
 
 func (it *Iterator) setPos(x []byte) {
 	it.pos = append(it.pos[:0], x...)
 }
 
-func (it *Iterator) setPosAfter(x []byte) {
-	it.setPos(x)
-	it.pos = append(it.pos, 0x00)
+func (it *Iterator) getSpan() Span {
+	return Span{
+		Start: it.pos,
+		End:   it.span.End,
+	}
 }
 
-func (it *Iterator) initRoot(ctx context.Context) error {
-	i := len(it.srs) - 1
-	if it.srs[i] != nil {
-		return nil
-	}
-	it.srs[i] = NewStreamReader(it.s, it.op, []Index{rootToIndex(it.root)})
-	if i == 0 {
-		if err := it.srs[i].Seek(ctx, it.pos); err != nil {
-			return err
-		}
-	} else {
-		if err := it.srs[i].SeekIndexes(ctx, it.pos); err != nil {
-			return err
+func filterEntries(xs []Entry, span Span) []Entry {
+	ret := xs[:0]
+	for i := range xs {
+		if span.Contains(xs[i].Key) {
+			ret = append(ret, xs[i])
 		}
 	}
-	return nil
+	return ret
 }
 
-// readIndexes
-func readIndexes(ctx context.Context, it kvstreams.Iterator) ([]Index, error) {
-	var idxs []Index
-	if err := kvstreams.ForEach(ctx, it, func(ent Entry) error {
-		idx, err := entryToIndex(ent)
-		if err != nil {
-			return err
+// filterIndexes removes indexes that could not point to items in span.
+func filterIndexes(xs []Entry, span Span) []Entry {
+	ret := xs[:0]
+	for i := range xs {
+		if span.LessThan(xs[i].Key) {
+			continue
 		}
-		if len(idxs) > 0 {
-			prev := idxs[len(idxs)-1].First
-			next := idx.First
-			if bytes.Compare(prev, next) >= 0 {
-				return errors.Errorf("ptree: indexes out of order %q >= %q", prev, next)
-			}
+		if i+1 < len(xs) && span.GreaterThan(xs[i+1].Key) {
+			continue
 		}
-		idxs = append(idxs, idx)
-		return nil
-	}); err != nil {
-		return nil, err
+		ret = append(ret, xs[i])
 	}
-	return idxs, nil
+	return ret
 }

--- a/pkg/gotkv/ptree/iterator.go
+++ b/pkg/gotkv/ptree/iterator.go
@@ -128,10 +128,11 @@ func (it *Iterator) syncLevel() int {
 	// top is maximum index where the level has more than 1 entry
 	// top is required because indexes at the right most side of the tree cannot be copied
 	// since they could point to incomplete nodes.
+	// the iterator's span causes us to consider some otherwise complete nodes incomplete.
 	var top int
 	for i := len(it.levels) - 1; i >= 0; i-- {
 		top = i
-		if len(it.levels[i]) > 1 && bytes.Compare(it.levels[i][1].Key, it.span.End) < 0 {
+		if len(it.levels[i]) > 1 && (it.span.End == nil || bytes.Compare(it.levels[i][1].Key, it.span.End) < 0) {
 			break
 		}
 	}

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gotvc/got/pkg/gdat"
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const maxTreeDepth = 255
@@ -20,42 +21,27 @@ type Root struct {
 
 // Copy copies all the entries from it to b.
 func Copy(ctx context.Context, b *Builder, it *Iterator) error {
-	// TODO: take advantage of index copying
 	var ent Entry
-	for err := it.Next(ctx, &ent); err != kvstreams.EOS; err = it.Next(ctx, &ent) {
-		if err != nil {
+	for {
+		level := min(b.syncLevel(), it.syncLevel())
+		if err := it.next(ctx, level, &ent); err != nil {
+			if err == kvstreams.EOS {
+				return nil
+			}
 			return err
 		}
-		if err := b.Put(ctx, ent.Key, ent.Value); err != nil {
+		// TODO: remove this check
+		if level > 0 {
+			idx, err := entryToIndex(ent)
+			if err != nil {
+				logrus.Info(ent)
+				panic(err)
+			}
+			logrus.Infof("copying index: level=%d first=%q", level, idx.First)
+		}
+		if err := b.put(ctx, level, ent.Key, ent.Value); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-func entryToIndex(ent Entry) (Index, error) {
-	ref, err := gdat.ParseRef(ent.Value)
-	if err != nil {
-		return Index{}, err
-	}
-	return Index{
-		First: append([]byte{}, ent.Key...),
-		Ref:   *ref,
-	}, nil
-}
-
-func indexToRoot(idx Index, depth uint8) Root {
-	return Root{
-		Ref:   idx.Ref,
-		First: idx.First,
-		Depth: depth,
-	}
-}
-
-func rootToIndex(r Root) Index {
-	return Index{
-		Ref:   r.Ref,
-		First: r.First,
 	}
 }
 
@@ -105,4 +91,30 @@ func PointsToEntries(root Root) bool {
 
 func PointsToIndexes(root Root) bool {
 	return root.Depth > 0
+}
+
+func entryToIndex(ent Entry) (Index, error) {
+	ref, err := gdat.ParseRef(ent.Value)
+	if err != nil {
+		return Index{}, err
+	}
+	return Index{
+		First: append([]byte{}, ent.Key...),
+		Ref:   *ref,
+	}, nil
+}
+
+func indexToRoot(idx Index, depth uint8) Root {
+	return Root{
+		Ref:   idx.Ref,
+		First: idx.First,
+		Depth: depth,
+	}
+}
+
+func rootToIndex(r Root) Index {
+	return Index{
+		Ref:   r.Ref,
+		First: r.First,
+	}
 }

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gotvc/got/pkg/gdat"
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const maxTreeDepth = 255
@@ -29,15 +28,6 @@ func Copy(ctx context.Context, b *Builder, it *Iterator) error {
 				return nil
 			}
 			return err
-		}
-		// TODO: remove this check
-		if level > 0 {
-			idx, err := entryToIndex(ent)
-			if err != nil {
-				logrus.Info(ent)
-				panic(err)
-			}
-			logrus.Infof("copying index: level=%d first=%q", level, idx.First)
 		}
 		if err := b.put(ctx, level, ent.Key, ent.Value); err != nil {
 			return err

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -71,18 +71,8 @@ func ListChildren(ctx context.Context, s cadata.Store, op *gdat.Operator, root R
 
 // ListEntries
 func ListEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index) ([]Entry, error) {
-	var ents []Entry
 	sr := NewStreamReader(s, op, []Index{idx})
-	for {
-		var ent Entry
-		if err := sr.Next(ctx, &ent); err != nil {
-			if err == kvstreams.EOS {
-				return ents, nil
-			}
-			return nil, err
-		}
-		ents = append(ents, ent)
-	}
+	return kvstreams.Collect(ctx, sr)
 }
 
 func PointsToEntries(root Root) bool {
@@ -102,6 +92,10 @@ func entryToIndex(ent Entry) (Index, error) {
 		First: append([]byte{}, ent.Key...),
 		Ref:   *ref,
 	}, nil
+}
+
+func indexToEntry(idx Index) Entry {
+	return Entry{Key: idx.First, Value: gdat.MarshalRef(idx.Ref)}
 }
 
 func indexToRoot(idx Index, depth uint8) Root {


### PR DESCRIPTION
Adds index copying to `ptree.Copy` function.  Copying indexes makes `Copy` `O(log(n))` where `n` is the number of nodes in the tree.