### PR TITLE
ptree: adds CompareFunc to control sort order of keys

### DIFF
--- a/pkg/branches/volume.go
+++ b/pkg/branches/volume.go
@@ -111,7 +111,8 @@ func syncStores(ctx context.Context, src, dst StoreTriple, snap gotvc.Snapshot) 
 	return gotvc.Sync(ctx, src.VC, dst.VC, snap, func(root gotfs.Root) error {
 		ctx, cf := metrics.Child(ctx, "syncing gotfs")
 		defer cf()
-		return gotfs.Sync(ctx, src.FS, src.Raw, dst.FS, dst.Raw, root)
+		fsop := gotfs.NewOperator()
+		return fsop.Sync(ctx, src.FS, src.Raw, dst.FS, dst.Raw, root)
 	})
 }
 
@@ -129,7 +130,8 @@ func CleanupVolume(ctx context.Context, vol Volume) error {
 	keep := [3]stores.MemSet{{}, {}, {}}
 	if start != nil {
 		if err := gotvc.Populate(ctx, ss[0], *start, keep[0], func(root gotfs.Root) error {
-			return gotfs.Populate(ctx, ss[1], root, keep[1], keep[2])
+			fsop := gotfs.NewOperator()
+			return fsop.Populate(ctx, ss[1], root, keep[1], keep[2])
 		}); err != nil {
 			return err
 		}

--- a/pkg/gotfs/dirs.go
+++ b/pkg/gotfs/dirs.go
@@ -133,7 +133,7 @@ type dirIterator struct {
 	s    Store
 	x    Root
 	p    string
-	iter gotkv.Iterator
+	iter *gotkv.Iterator
 }
 
 func (o *Operator) newDirIterator(ctx context.Context, s Store, x Root, p string) (*dirIterator, error) {

--- a/pkg/gotfs/files.go
+++ b/pkg/gotfs/files.go
@@ -109,7 +109,7 @@ func (o *Operator) ReadFileAt(ctx context.Context, ms, ds Store, x Root, p strin
 	return n, io.EOF
 }
 
-func (o *Operator) readFromIterator(ctx context.Context, it gotkv.Iterator, ds cadata.Store, start uint64, buf []byte) (int, error) {
+func (o *Operator) readFromIterator(ctx context.Context, it *gotkv.Iterator, ds cadata.Store, start uint64, buf []byte) (int, error) {
 	var ent gotkv.Entry
 	if err := it.Next(ctx, &ent); err != nil {
 		return 0, err

--- a/pkg/gotfs/sync.go
+++ b/pkg/gotfs/sync.go
@@ -11,8 +11,8 @@ import (
 // Sync ensures dst has all the data reachable from root
 // dst and src should both be metadata stores.
 // copyData will be called to sync metadata
-func Sync(ctx context.Context, srcMeta, srcData, dstMeta, dstData Store, root Root) error {
-	return gotkv.Sync(ctx, srcMeta, dstMeta, root, func(ent gotkv.Entry) error {
+func (o *Operator) Sync(ctx context.Context, srcMeta, srcData, dstMeta, dstData Store, root Root) error {
+	return o.gotkv.Sync(ctx, srcMeta, dstMeta, root, func(ent gotkv.Entry) error {
 		if isExtentKey(ent.Key) {
 			part, err := parseExtent(ent.Value)
 			if err != nil {
@@ -29,8 +29,8 @@ func Sync(ctx context.Context, srcMeta, srcData, dstMeta, dstData Store, root Ro
 }
 
 // Populate adds the ID for all the metadata blobs to mdSet and all the data blobs to dataSet
-func Populate(ctx context.Context, s Store, root Root, mdSet, dataSet cadata.Set) error {
-	return gotkv.Populate(ctx, s, root, mdSet, func(ent gotkv.Entry) error {
+func (o *Operator) Populate(ctx context.Context, s Store, root Root, mdSet, dataSet cadata.Set) error {
+	return o.gotkv.Populate(ctx, s, root, mdSet, func(ent gotkv.Entry) error {
 		if isExtentKey(ent.Key) {
 			part, err := parseExtent(ent.Value)
 			if err != nil {

--- a/pkg/gotkv/ptree/builder.go
+++ b/pkg/gotkv/ptree/builder.go
@@ -21,7 +21,7 @@ type Builder struct {
 	ctx context.Context
 }
 
-func NewBuilder(s cadata.Store, op *gdat.Operator, avgSize, maxSize int, seed *[16]byte) *Builder {
+func NewBuilder(op *gdat.Operator, avgSize, maxSize int, seed *[16]byte, cmp CompareFunc, s cadata.Store) *Builder {
 	b := &Builder{
 		s:       s,
 		op:      op,

--- a/pkg/gotkv/ptree/debug.go
+++ b/pkg/gotkv/ptree/debug.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 )
 
-func DebugTree(ctx context.Context, s cadata.Store, x Root, w io.Writer) error {
+func DebugTree(ctx context.Context, cmp CompareFunc, s cadata.Store, x Root, w io.Writer) error {
 	bw, ok := w.(*bufio.Writer)
 	if !ok {
 		bw = bufio.NewWriter(w)
@@ -25,7 +25,7 @@ func DebugTree(ctx context.Context, s cadata.Store, x Root, w io.Writer) error {
 			indent += "  "
 		}
 		ctx := context.TODO()
-		sr := NewStreamReader(s, &op, []Index{{Ref: x.Ref, First: x.First}})
+		sr := NewStreamReader(s, &op, cmp, []Index{{Ref: x.Ref, First: x.First}})
 		fmt.Fprintf(bw, "%sTREE NODE: %s %d\n", indent, x.Ref.CID.String(), x.Depth)
 		if x.Depth == 0 {
 			for {

--- a/pkg/gotkv/ptree/iterator.go
+++ b/pkg/gotkv/ptree/iterator.go
@@ -11,16 +11,17 @@ import (
 )
 
 type Iterator struct {
-	s    cadata.Store
-	op   *gdat.Operator
-	root Root
-	span Span
+	op      *gdat.Operator
+	compare CompareFunc
+	s       cadata.Store
+	root    Root
+	span    Span
 
 	levels [][]Entry
 	pos    []byte
 }
 
-func NewIterator(s cadata.Store, op *gdat.Operator, root Root, span Span) *Iterator {
+func NewIterator(op *gdat.Operator, cmp CompareFunc, s cadata.Store, root Root, span Span) *Iterator {
 	it := &Iterator{
 		s:      s,
 		op:     op,
@@ -100,7 +101,7 @@ func (it *Iterator) getEntries(ctx context.Context, level int) ([]Entry, error) 
 			return nil, errors.Wrapf(err, "converting entry to index at level %d", level)
 		}
 		it.advanceLevel(level+1, false)
-		ents, err := ListEntries(ctx, it.s, it.op, idx)
+		ents, err := ListEntries(ctx, it.op, it.compare, it.s, idx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gotkv/ptree/kv_test.go
+++ b/pkg/gotkv/ptree/kv_test.go
@@ -16,7 +16,7 @@ func TestAddPrefix(t *testing.T) {
 	ctx := context.Background()
 	s := cadata.NewMem(cadata.DefaultHash, defaultMaxSize)
 	op := gdat.NewOperator()
-	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
+	b := NewBuilder(&op, defaultAvgSize, defaultMaxSize, nil, bytes.Compare, s)
 
 	const N = 1e4
 	generateEntries(N, func(ent Entry) {
@@ -32,7 +32,7 @@ func TestAddPrefix(t *testing.T) {
 
 	t.Logf("produced %d blobs", s.Len())
 
-	it := NewIterator(s, &op, root2, kvstreams.TotalSpan())
+	it := NewIterator(&op, bytes.Compare, s, root2, kvstreams.TotalSpan())
 	var ent Entry
 	for i := 0; i < N; i++ {
 		err := it.Next(ctx, &ent)

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -9,6 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CompareFunc compares 2 keys
+type CompareFunc = func(a, b []byte) int
+
 const maxTreeDepth = 255
 
 // Root is the root of the tree
@@ -36,11 +39,11 @@ func Copy(ctx context.Context, b *Builder, it *Iterator) error {
 }
 
 // ListChildren returns the immediate children of root if any.
-func ListChildren(ctx context.Context, s cadata.Store, op *gdat.Operator, root Root) ([]Index, error) {
+func ListChildren(ctx context.Context, op *gdat.Operator, cmp CompareFunc, s cadata.Store, root Root) ([]Index, error) {
 	if PointsToEntries(root) {
 		return nil, errors.Errorf("cannot list children of root with depth=%d", root.Depth)
 	}
-	sr := NewStreamReader(s, op, []Index{rootToIndex(root)})
+	sr := NewStreamReader(s, op, cmp, []Index{rootToIndex(root)})
 	var idxs []Index
 	var ent Entry
 	for {
@@ -61,8 +64,8 @@ func ListChildren(ctx context.Context, s cadata.Store, op *gdat.Operator, root R
 
 // ListEntries returns a slice of all the entries pointed to by idx, directly.
 // If idx points to other indexes directly, then ListEntries returns the entries for those indexes.
-func ListEntries(ctx context.Context, s cadata.Store, op *gdat.Operator, idx Index) ([]Entry, error) {
-	sr := NewStreamReader(s, op, []Index{idx})
+func ListEntries(ctx context.Context, op *gdat.Operator, cmp CompareFunc, s cadata.Store, idx Index) ([]Entry, error) {
+	sr := NewStreamReader(s, op, cmp, []Index{idx})
 	return kvstreams.Collect(ctx, sr)
 }
 

--- a/pkg/gotkv/ptree/ptree_test.go
+++ b/pkg/gotkv/ptree/ptree_test.go
@@ -1,6 +1,7 @@
 package ptree
 
 import (
+	"bytes"
 	"context"
 	"strconv"
 	"testing"
@@ -15,7 +16,7 @@ func TestBuilder(t *testing.T) {
 	ctx := context.Background()
 	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := gdat.NewOperator()
-	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
+	b := NewBuilder(&op, defaultAvgSize, defaultMaxSize, nil, bytes.Compare, s)
 
 	generateEntries(1e4, func(ent Entry) {
 		err := b.Put(ctx, ent.Key, ent.Value)
@@ -31,7 +32,7 @@ func TestBuildIterate(t *testing.T) {
 	ctx := context.Background()
 	s := cadata.NewMem(cadata.DefaultHash, cadata.DefaultMaxSize)
 	op := gdat.NewOperator()
-	b := NewBuilder(s, &op, defaultAvgSize, defaultMaxSize, nil)
+	b := NewBuilder(&op, defaultAvgSize, defaultMaxSize, nil, bytes.Compare, s)
 
 	const N = 1e4
 	generateEntries(N, func(ent Entry) {
@@ -44,7 +45,7 @@ func TestBuildIterate(t *testing.T) {
 
 	t.Logf("produced %d blobs", s.Len())
 
-	it := NewIterator(s, &op, *root, Span{})
+	it := NewIterator(&op, bytes.Compare, s, *root, Span{})
 	var ent Entry
 	for i := 0; i < N; i++ {
 		err := it.Next(ctx, &ent)
@@ -60,7 +61,7 @@ func TestCopy(t *testing.T) {
 	ctx := context.Background()
 	s := cadata.NewMem(cadata.DefaultHash, maxSize)
 	op := gdat.NewOperator()
-	b := NewBuilder(s, &op, averageSize, maxSize, nil)
+	b := NewBuilder(&op, averageSize, maxSize, nil, bytes.Compare, s)
 	const N = 1e6
 	generateEntries(N, func(ent Entry) {
 		err := b.Put(ctx, ent.Key, ent.Value)
@@ -71,8 +72,8 @@ func TestCopy(t *testing.T) {
 	require.NotNil(t, root)
 
 	t.Log("being copying")
-	it := NewIterator(s, &op, *root, Span{})
-	b2 := NewBuilder(s, &op, averageSize, maxSize, nil)
+	it := NewIterator(&op, bytes.Compare, s, *root, Span{})
+	b2 := NewBuilder(&op, averageSize, maxSize, nil, bytes.Compare, s)
 	require.NoError(t, Copy(ctx, b2, it))
 	root2, err := b2.Finish(ctx)
 	require.NoError(t, err)

--- a/pkg/gotkv/ptree/stream_test.go
+++ b/pkg/gotkv/ptree/stream_test.go
@@ -55,7 +55,7 @@ func TestStreamRW(t *testing.T) {
 	err := sw.Flush(ctx)
 	require.NoError(t, err)
 
-	sr := NewStreamReader(s, &op, idxs)
+	sr := NewStreamReader(s, &op, bytes.Compare, idxs)
 	var ent Entry
 	for i := 0; i < N; i++ {
 		err := sr.Next(ctx, &ent)

--- a/pkg/gotrepo/debug.go
+++ b/pkg/gotrepo/debug.go
@@ -1,6 +1,7 @@
 package gotrepo
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -50,5 +51,5 @@ func (r *Repo) DebugKV(ctx context.Context, w io.Writer) error {
 	if x == nil {
 		return errors.Errorf("no snapshot, no root")
 	}
-	return ptree.DebugTree(ctx, vol.FSStore, x.Root, w)
+	return ptree.DebugTree(ctx, bytes.Compare, vol.FSStore, x.Root, w)
 }


### PR DESCRIPTION
- The probabilistic tree data-structure supports any comparable keys, this exposes that functionality to consumers.
- GotKV and GotFS still depend on AddPrefix and RemovePrefix, so this will likely not be used within Got in the near term.
- Changes order of ptree function arguments to follow the convention that earlier arguments change less frequently than later arguments.  e.g. all of the tree parameters are first now, then the store, then the root, then other arguments last.
