### PR TITLE
ptree: refactor

### DIFF
--- a/pkg/gdat/operator.go
+++ b/pkg/gdat/operator.go
@@ -56,7 +56,7 @@ func NewOperator(opts ...Option) Operator {
 	return o
 }
 
-func (o *Operator) Post(ctx context.Context, s Store, data []byte) (*Ref, error) {
+func (o *Operator) Post(ctx context.Context, s cadata.Poster, data []byte) (*Ref, error) {
 	id, dek, err := o.postEncrypt(ctx, s, o.kf, data)
 	if err != nil {
 		return nil, err

--- a/pkg/gotkv/ptree/kv.go
+++ b/pkg/gotkv/ptree/kv.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/brendoncarroll/go-state/cadata"
-	"github.com/gotvc/got/pkg/gdat"
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 	"github.com/pkg/errors"
 )
@@ -16,9 +14,12 @@ type (
 )
 
 // MaxEntry returns the entry in span with the greatest (ordered last) key.
-func MaxEntry(ctx context.Context, cmp CompareFunc, s cadata.Getter, x Root, span Span) (*Entry, error) {
-	op := gdat.NewOperator()
-	sr := NewStreamReader(s, &op, cmp, []Index{rootToIndex(x)})
+func MaxEntry(ctx context.Context, cmp CompareFunc, s Getter, x Root, span Span) (*Entry, error) {
+	sr := NewStreamReader(StreamReaderParams{
+		Store:   s,
+		Compare: cmp,
+		Indexes: []Index{rootToIndex(x)},
+	})
 	ent, err := maxEntry(ctx, sr, span.End)
 	if err != nil {
 		return nil, err
@@ -69,7 +70,7 @@ func AddPrefix(x Root, prefix []byte) Root {
 }
 
 // RemovePrefix returns a new version of root with the prefix removed from all the keys
-func RemovePrefix(ctx context.Context, cmp CompareFunc, s cadata.Getter, x Root, prefix []byte) (*Root, error) {
+func RemovePrefix(ctx context.Context, cmp CompareFunc, s Getter, x Root, prefix []byte) (*Root, error) {
 	if yes, err := HasPrefix(ctx, cmp, s, x, prefix); err != nil {
 		return nil, err
 	} else if yes {
@@ -84,7 +85,7 @@ func RemovePrefix(ctx context.Context, cmp CompareFunc, s cadata.Getter, x Root,
 }
 
 // HasPrefix returns true if the tree rooted at x only has keys which are prefixed with prefix
-func HasPrefix(ctx context.Context, cmp CompareFunc, s cadata.Getter, x Root, prefix []byte) (bool, error) {
+func HasPrefix(ctx context.Context, cmp CompareFunc, s Getter, x Root, prefix []byte) (bool, error) {
 	if !bytes.HasPrefix(x.First, prefix) {
 		return false, nil
 	}

--- a/pkg/gotkv/ptree/kv_test.go
+++ b/pkg/gotkv/ptree/kv_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/brendoncarroll/go-state/cadata"
-	"github.com/gotvc/got/pkg/gdat"
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 	"github.com/stretchr/testify/require"
 )
@@ -15,8 +14,13 @@ func TestAddPrefix(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s := cadata.NewMem(cadata.DefaultHash, defaultMaxSize)
-	op := gdat.NewOperator()
-	b := NewBuilder(&op, defaultAvgSize, defaultMaxSize, nil, bytes.Compare, s)
+	b := NewBuilder(BuilderParams{
+		Store:    wrapStore(s),
+		MeanSize: defaultAvgSize,
+		MaxSize:  defaultMaxSize,
+		Seed:     nil,
+		Compare:  bytes.Compare,
+	})
 
 	const N = 1e4
 	generateEntries(N, func(ent Entry) {
@@ -32,7 +36,12 @@ func TestAddPrefix(t *testing.T) {
 
 	t.Logf("produced %d blobs", s.Len())
 
-	it := NewIterator(&op, bytes.Compare, s, root2, kvstreams.TotalSpan())
+	it := NewIterator(IteratorParams{
+		Compare: bytes.Compare,
+		Store:   wrapStore(s),
+		Root:    root2,
+		Span:    kvstreams.TotalSpan(),
+	})
 	var ent Entry
 	for i := 0; i < N; i++ {
 		err := it.Next(ctx, &ent)

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -10,13 +10,19 @@ import (
 
 // Getter is used to retrieve nodes from storage by Ref
 type Getter interface {
-	Get(ctx context.Context, ref Ref, buf []byte) (int, error)
+	// Get fills buf with data at ref, or returns an error.
+	// Get will always return an n <= MaxSize()
+	Get(ctx context.Context, ref Ref, buf []byte) (n int, err error)
+	// MaxSize returns the maximum amount of bytes that could be stored at a ref.
 	MaxSize() int
 }
 
 // Poster is used to store nodes in storage and retrieve a Ref
 type Poster interface {
+	// Posts stores the data and returns a Ref for retrieving it.
 	Post(ctx context.Context, data []byte) (Ref, error)
+	// MaxSize is the maximum amount of data that can be Posted in bytes
+	MaxSize() int
 }
 
 type Store interface {

--- a/pkg/gotkv/ptree/ptree.go
+++ b/pkg/gotkv/ptree/ptree.go
@@ -3,11 +3,26 @@ package ptree
 import (
 	"context"
 
-	"github.com/brendoncarroll/go-state/cadata"
 	"github.com/gotvc/got/pkg/gdat"
 	"github.com/gotvc/got/pkg/gotkv/kvstreams"
 	"github.com/pkg/errors"
 )
+
+// Getter is used to retrieve nodes from storage by Ref
+type Getter interface {
+	Get(ctx context.Context, ref Ref, buf []byte) (int, error)
+	MaxSize() int
+}
+
+// Poster is used to store nodes in storage and retrieve a Ref
+type Poster interface {
+	Post(ctx context.Context, data []byte) (Ref, error)
+}
+
+type Store interface {
+	Getter
+	Poster
+}
 
 // CompareFunc compares 2 keys
 type CompareFunc = func(a, b []byte) int
@@ -42,11 +57,15 @@ func Copy(ctx context.Context, b *Builder, it *Iterator) error {
 }
 
 // ListChildren returns the immediate children of root if any.
-func ListChildren(ctx context.Context, op *gdat.Operator, cmp CompareFunc, s cadata.Getter, root Root) ([]Index, error) {
+func ListChildren(ctx context.Context, cmp CompareFunc, s Getter, root Root) ([]Index, error) {
 	if PointsToEntries(root) {
 		return nil, errors.Errorf("cannot list children of root with depth=%d", root.Depth)
 	}
-	sr := NewStreamReader(s, op, cmp, []Index{rootToIndex(root)})
+	sr := NewStreamReader(StreamReaderParams{
+		Store:   s,
+		Compare: cmp,
+		Indexes: []Index{rootToIndex(root)},
+	})
 	var idxs []Index
 	var ent Entry
 	for {
@@ -67,8 +86,12 @@ func ListChildren(ctx context.Context, op *gdat.Operator, cmp CompareFunc, s cad
 
 // ListEntries returns a slice of all the entries pointed to by idx, directly.
 // If idx points to other indexes directly, then ListEntries returns the entries for those indexes.
-func ListEntries(ctx context.Context, op *gdat.Operator, cmp CompareFunc, s cadata.Getter, idx Index) ([]Entry, error) {
-	sr := NewStreamReader(s, op, cmp, []Index{idx})
+func ListEntries(ctx context.Context, cmp CompareFunc, s Getter, idx Index) ([]Entry, error) {
+	sr := NewStreamReader(StreamReaderParams{
+		Store:   s,
+		Compare: cmp,
+		Indexes: []Index{idx},
+	})
 	return kvstreams.Collect(ctx, sr)
 }
 


### PR DESCRIPTION
- constructors now take *Params structs
- ptree.Getter, ptree.Poster, and ptree.Store consolidate the dependencies on gdat.Operator and cadata.Store.  It also paves the way for a generic Ref type parameter.