### PR TITLE
gotfs: Root type distinct from gotkv.Root

### DIFF
--- a/pkg/gotfs/builder.go
+++ b/pkg/gotfs/builder.go
@@ -94,11 +94,11 @@ func (b *Builder) writeExtents(ctx context.Context, exts []*Extent) error {
 	return nil
 }
 
-func (b *Builder) copyFrom(ctx context.Context, root Root, span gotkv.Span) error {
+func (b *Builder) copyFrom(ctx context.Context, root gotkv.Root, span gotkv.Span) error {
 	if err := b.b.CopyFrom(ctx, root, span); err != nil {
 		return err
 	}
-	p, info, err := b.o.MaxInfo(ctx, b.ms, root, span)
+	p, info, err := b.o.maxInfo(ctx, b.ms, root, span)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,8 @@ func (b *Builder) copyFrom(ctx context.Context, root Root, span gotkv.Span) erro
 // Finish is idempotent, and is safe to call multiple times.
 // Not calling finish is not an error, the builder does not allocate resources other than memory.
 func (b *Builder) Finish() (*Root, error) {
-	return b.b.Finish(b.ctx)
+	root, err := b.b.Finish(b.ctx)
+	return newRoot(root), err
 }
 
 func (b *Builder) IsFinished() bool {

--- a/pkg/gotfs/dirs.go
+++ b/pkg/gotfs/dirs.go
@@ -21,7 +21,9 @@ type DirEnt struct {
 // NewEmpty creates a new filesystem with an empty root directory
 func (o *Operator) NewEmpty(ctx context.Context, s Store) (*Root, error) {
 	b := o.NewBuilder(ctx, s, stores.NewVoid())
-	b.Mkdir("/", 0o755)
+	if err := b.Mkdir("/", 0o755); err != nil {
+		return nil, err
+	}
 	return b.Finish()
 }
 

--- a/pkg/gotfs/dirs.go
+++ b/pkg/gotfs/dirs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brendoncarroll/go-state/posixfs"
 	"github.com/gotvc/got/pkg/gotkv"
+	"github.com/gotvc/got/pkg/stores"
 	"github.com/pkg/errors"
 )
 
@@ -17,9 +18,11 @@ type DirEnt struct {
 	Mode os.FileMode
 }
 
-// NewEmpty creates a new filesystem with nothing in it.
+// NewEmpty creates a new filesystem with an empty root directory
 func (o *Operator) NewEmpty(ctx context.Context, s Store) (*Root, error) {
-	return o.gotkv.NewEmpty(ctx, s)
+	b := o.NewBuilder(ctx, s, stores.NewVoid())
+	b.Mkdir("/", 0o755)
+	return b.Finish()
 }
 
 // Mkdir creates a directory at path p
@@ -101,7 +104,8 @@ func (o *Operator) RemoveAll(ctx context.Context, s Store, x Root, p string) (*R
 	}
 	k := makeInfoKey(p)
 	span := gotkv.PrefixSpan(k)
-	return o.gotkv.DeleteSpan(ctx, s, x, span)
+	root, err := o.gotkv.DeleteSpan(ctx, s, *x.toGotKV(), span)
+	return newRoot(root), err
 }
 
 func dirSpan(p string) gotkv.Span {
@@ -129,7 +133,7 @@ func (o *Operator) newDirIterator(ctx context.Context, s Store, x Root, p string
 		return nil, err
 	}
 	span := dirSpan(p)
-	iter := o.gotkv.NewIterator(s, x, span)
+	iter := o.gotkv.NewIterator(s, *x.toGotKV(), span)
 	if err := iter.Next(ctx, &gotkv.Entry{}); err != nil {
 		return nil, err
 	}

--- a/pkg/gotfs/files.go
+++ b/pkg/gotfs/files.go
@@ -66,7 +66,7 @@ func (o *Operator) CreateFile(ctx context.Context, ms, ds Store, x Root, p strin
 func (o *Operator) SizeOfFile(ctx context.Context, s Store, x Root, p string) (uint64, error) {
 	p = cleanPath(p)
 	k := makeExtentPrefix(p)
-	return o.lob.SizeOf(ctx, s, x, k)
+	return o.lob.SizeOf(ctx, s, *x.toGotKV(), k)
 }
 
 // ReadFileAt fills `buf` with data in the file at `p` starting at offset `start`
@@ -88,5 +88,5 @@ func (o *Operator) NewReader(ctx context.Context, ms, ds Store, x Root, p string
 		return nil, err
 	}
 	k := makeExtentPrefix(p)
-	return o.lob.NewReader(ctx, ms, ds, x, k)
+	return o.lob.NewReader(ctx, ms, ds, *x.toGotKV(), k)
 }

--- a/pkg/gotfs/info.go
+++ b/pkg/gotfs/info.go
@@ -59,11 +59,16 @@ func (o *Operator) PutInfo(ctx context.Context, s Store, x Root, p string, md *I
 		return nil, err
 	}
 	k := makeInfoKey(p)
-	return o.gotkv.Put(ctx, s, x, k, md.marshal())
+	root, err := o.gotkv.Put(ctx, s, *x.toGotKV(), k, md.marshal())
+	return newRoot(root), err
 }
 
 // GetInfo retrieves the metadata at p if it exists and errors otherwise
 func (o *Operator) GetInfo(ctx context.Context, s Store, x Root, p string) (*Info, error) {
+	return o.getInfo(ctx, s, x.ToGotKV(), p)
+}
+
+func (o *Operator) getInfo(ctx context.Context, s Store, x gotkv.Root, p string) (*Info, error) {
 	p = cleanPath(p)
 	var md *Info
 	err := o.gotkv.GetF(ctx, s, x, makeInfoKey(p), func(data []byte) error {

--- a/pkg/gotfs/sync.go
+++ b/pkg/gotfs/sync.go
@@ -12,7 +12,7 @@ import (
 // dst and src should both be metadata stores.
 // copyData will be called to sync metadata
 func (o *Operator) Sync(ctx context.Context, srcMeta, srcData, dstMeta, dstData Store, root Root) error {
-	return o.gotkv.Sync(ctx, srcMeta, dstMeta, root, func(ent gotkv.Entry) error {
+	return o.gotkv.Sync(ctx, srcMeta, dstMeta, *root.toGotKV(), func(ent gotkv.Entry) error {
 		if isExtentKey(ent.Key) {
 			ext, err := parseExtent(ent.Value)
 			if err != nil {
@@ -26,7 +26,7 @@ func (o *Operator) Sync(ctx context.Context, srcMeta, srcData, dstMeta, dstData 
 
 // Populate adds the ID for all the metadata blobs to mdSet and all the data blobs to dataSet
 func (o *Operator) Populate(ctx context.Context, s Store, root Root, mdSet, dataSet cadata.Set) error {
-	return o.gotkv.Populate(ctx, s, root, mdSet, func(ent gotkv.Entry) error {
+	return o.gotkv.Populate(ctx, s, *root.toGotKV(), mdSet, func(ent gotkv.Entry) error {
 		if isExtentKey(ent.Key) {
 			ext, err := parseExtent(ent.Value)
 			if err != nil {

--- a/pkg/gotrepo/debug.go
+++ b/pkg/gotrepo/debug.go
@@ -50,5 +50,5 @@ func (r *Repo) DebugKV(ctx context.Context, w io.Writer) error {
 	if x == nil {
 		return errors.Errorf("no snapshot, no root")
 	}
-	return gotkv.DebugTree(ctx, vol.FSStore, x.Root, w)
+	return gotkv.DebugTree(ctx, vol.FSStore, x.Root.ToGotKV(), w)
 }

--- a/pkg/gotrepo/repo_test.go
+++ b/pkg/gotrepo/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -63,6 +64,7 @@ func TestCommit(t *testing.T) {
 	require.NoError(t, repo.Put(ctx, p2))
 	err = repo.Commit(ctx, gotvc.SnapInfo{})
 	require.NoError(t, err)
+	repo.DebugFS(ctx, os.Stderr)
 
 	checkNotExists(t, repo, p)
 	checkFileContent(t, repo, p2, strings.NewReader(fileContents))

--- a/pkg/gotrepo/repo_test.go
+++ b/pkg/gotrepo/repo_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -64,7 +63,6 @@ func TestCommit(t *testing.T) {
 	require.NoError(t, repo.Put(ctx, p2))
 	err = repo.Commit(ctx, gotvc.SnapInfo{})
 	require.NoError(t, err)
-	repo.DebugFS(ctx, os.Stderr)
 
 	checkNotExists(t, repo, p)
 	checkFileContent(t, repo, p2, strings.NewReader(fileContents))

--- a/pkg/stores/stores.go
+++ b/pkg/stores/stores.go
@@ -66,3 +66,7 @@ func NewFSStore(x posixfs.FS, maxSize int) cadata.Store {
 func NewMem() cadata.Store {
 	return cadata.NewMem(gdat.Hash, 1<<22)
 }
+
+func NewVoid() cadata.Store {
+	return cadata.NewVoid(gdat.Hash, 1<<22)
+}


### PR DESCRIPTION
All valid gotfs filesystems have`/` as the first key.  Having a distinct root type, allows the first key to be elided.

This change revealed a bunch of places where invalid filesystems were returned through the API.  Callers were required to understand how to use those Roots correctly in subsequent calls to end up with a valid filesystem.