### PR TITLE
branches: cleanup model.

### DIFF
--- a/e2etest/repo_test.go
+++ b/e2etest/repo_test.go
@@ -103,7 +103,7 @@ func createFile(t testing.TB, repoPath, p string, data []byte) {
 
 func createBranch(t testing.TB, r *got.Repo, name string) {
 	ctx := testutil.Context(t)
-	_, err := r.CreateBranch(ctx, name, branches.Metadata{})
+	_, err := r.CreateBranch(ctx, name, branches.Config{})
 	require.NoError(t, err)
 }
 

--- a/pkg/branches/mem.go
+++ b/pkg/branches/mem.go
@@ -1,0 +1,112 @@
+package branches
+
+import (
+	"context"
+	"sync"
+
+	"github.com/brendoncarroll/go-state/cadata"
+	"github.com/brendoncarroll/go-state/cells"
+	"github.com/brendoncarroll/go-tai64"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+type MemSpace struct {
+	newStore func() cadata.Store
+	newCell  func() cells.Cell
+
+	mu      sync.RWMutex
+	infos   map[string]Info
+	volumes map[string]Volume
+}
+
+func NewMem(newStore func() cadata.Store, newCell func() cells.Cell) Space {
+	return &MemSpace{
+		newStore: newStore,
+		newCell:  newCell,
+		infos:    map[string]Info{},
+		volumes:  make(map[string]Volume),
+	}
+}
+
+func (r *MemSpace) Get(ctx context.Context, name string) (*Info, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	info, exists := r.infos[name]
+	if !exists {
+		return nil, ErrNotExist
+	}
+	info = info.Clone()
+	return &info, nil
+}
+
+func (r *MemSpace) Create(ctx context.Context, name string, cfg Config) (*Info, error) {
+	if err := CheckName(name); err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.infos[name]; exists {
+		return nil, ErrExists
+	}
+	r.volumes[name] = Volume{
+		Cell:     r.newCell(),
+		VCStore:  r.newStore(),
+		FSStore:  r.newStore(),
+		RawStore: r.newStore(),
+	}
+	info := cfg.AsInfo()
+	info.CreatedAt = tai64.Now().TAI64()
+	r.infos[name] = info
+
+	info = info.Clone()
+	return &info, nil
+}
+
+func (r *MemSpace) Set(ctx context.Context, name string, cfg Config) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.infos[name]; !exists {
+		return ErrNotExist
+	}
+	info := r.infos[name]
+	info.Mode = cfg.Mode
+	info.Salt = slices.Clone(cfg.Salt)
+	info.Annotations = slices.Clone(cfg.Annotations)
+	r.infos[name] = info
+	return nil
+}
+
+func (r *MemSpace) Delete(ctx context.Context, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.infos, name)
+	delete(r.volumes, name)
+	return nil
+}
+
+func (r *MemSpace) List(ctx context.Context, span Span, limit int) (ret []string, _ error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := maps.Keys(r.infos)
+	slices.Sort(keys)
+	for _, name := range keys {
+		if limit > 0 && len(ret) >= limit {
+			break
+		}
+		if span.Contains(name) {
+			ret = append(ret, name)
+		}
+	}
+	return ret, nil
+}
+
+func (r *MemSpace) Open(ctx context.Context, name string) (*Volume, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.volumes[name]; !exists {
+		return nil, ErrNotExist
+	}
+	v := r.volumes[name]
+	return &v, nil
+}

--- a/pkg/branches/multi.go
+++ b/pkg/branches/multi.go
@@ -26,13 +26,13 @@ func NewMultiSpace(layers []Layer) (Space, error) {
 	return layered(layers), nil
 }
 
-func (r layered) Create(ctx context.Context, k string, md Metadata) (*Branch, error) {
+func (r layered) Create(ctx context.Context, k string, cfg Config) (*Info, error) {
 	layer, err := r.find(k)
 	if err != nil {
 		return nil, err
 	}
 	l := len(layer.Prefix)
-	return layer.Target.Create(ctx, k[l:], md)
+	return layer.Target.Create(ctx, k[l:], cfg)
 }
 
 func (r layered) Delete(ctx context.Context, k string) error {
@@ -44,16 +44,16 @@ func (r layered) Delete(ctx context.Context, k string) error {
 	return layer.Target.Delete(ctx, k[l:])
 }
 
-func (r layered) Set(ctx context.Context, k string, md Metadata) error {
+func (r layered) Set(ctx context.Context, k string, cfg Config) error {
 	layer, err := r.find(k)
 	if err != nil {
 		return err
 	}
 	l := len(layer.Prefix)
-	return layer.Target.Set(ctx, k[l:], md)
+	return layer.Target.Set(ctx, k[l:], cfg)
 }
 
-func (r layered) Get(ctx context.Context, k string) (*Branch, error) {
+func (r layered) Get(ctx context.Context, k string) (*Info, error) {
 	layer, err := r.find(k)
 	if err != nil {
 		return nil, ErrNotExist
@@ -87,6 +87,15 @@ func (r layered) List(ctx context.Context, span Span, limit int) (ret []string, 
 		}
 	}
 	return ret, err
+}
+
+func (s layered) Open(ctx context.Context, k string) (*Volume, error) {
+	layer, err := s.find(k)
+	if err != nil {
+		return nil, err
+	}
+	l := len(layer.Prefix)
+	return layer.Target.Open(ctx, k[l:])
 }
 
 func (r layered) find(k string) (Layer, error) {

--- a/pkg/branches/prefix.go
+++ b/pkg/branches/prefix.go
@@ -18,16 +18,16 @@ func NewPrefixSpace(inner Space, prefix string) PrefixSpace {
 	}
 }
 
-func (s PrefixSpace) Create(ctx context.Context, k string, md Metadata) (*Branch, error) {
-	return s.Target.Create(ctx, s.downward(k), md)
+func (s PrefixSpace) Create(ctx context.Context, k string, cfg Config) (*Info, error) {
+	return s.Target.Create(ctx, s.downward(k), cfg)
 }
 
-func (s PrefixSpace) Get(ctx context.Context, k string) (*Branch, error) {
+func (s PrefixSpace) Get(ctx context.Context, k string) (*Info, error) {
 	return s.Target.Get(ctx, s.downward(k))
 }
 
-func (s PrefixSpace) Set(ctx context.Context, k string, md Metadata) error {
-	return s.Target.Set(ctx, s.downward(k), md)
+func (s PrefixSpace) Set(ctx context.Context, k string, cfg Config) error {
+	return s.Target.Set(ctx, s.downward(k), cfg)
 }
 
 func (s PrefixSpace) Delete(ctx context.Context, k string) error {
@@ -55,6 +55,10 @@ func (s PrefixSpace) List(ctx context.Context, span Span, limit int) ([]string, 
 		names[i] = y
 	}
 	return names, nil
+}
+
+func (s PrefixSpace) Open(ctx context.Context, name string) (*Volume, error) {
+	return s.Target.Open(ctx, s.downward(name))
 }
 
 func (s PrefixSpace) downward(x string) string {

--- a/pkg/branches/testsuite.go
+++ b/pkg/branches/testsuite.go
@@ -16,7 +16,7 @@ func TestSpace(t *testing.T, newSpace func(t testing.TB) Space) {
 		b, err := x.Get(ctx, "test")
 		require.ErrorIs(t, err, ErrNotExist)
 		require.Nil(t, b)
-		_, err = x.Create(ctx, "test", Metadata{})
+		_, err = x.Create(ctx, "test", Config{})
 		require.NoError(t, err)
 		b, err = x.Get(ctx, "test")
 		require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestSpace(t *testing.T, newSpace func(t testing.TB) Space) {
 		x := newSpace(t)
 		const N = 100
 		for i := 0; i < N; i++ {
-			_, err := x.Create(ctx, "test"+strconv.Itoa(i), Metadata{})
+			_, err := x.Create(ctx, "test"+strconv.Itoa(i), Config{})
 			require.NoError(t, err)
 		}
 		names, err := x.List(ctx, TotalSpan(), 0)
@@ -40,9 +40,9 @@ func TestSpace(t *testing.T, newSpace func(t testing.TB) Space) {
 		ctx := testutil.Context(t)
 		x := newSpace(t)
 		var err error
-		_, err = x.Create(ctx, "test1", Metadata{})
+		_, err = x.Create(ctx, "test1", Config{})
 		require.NoError(t, err)
-		_, err = x.Create(ctx, "test2", Metadata{})
+		_, err = x.Create(ctx, "test2", Config{})
 		require.NoError(t, err)
 
 		_, err = x.Get(ctx, "test1")

--- a/pkg/gotcmd/adapters.go
+++ b/pkg/gotcmd/adapters.go
@@ -32,7 +32,7 @@ func newHTTPCmd(open func() (*gotrepo.Repo, error)) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		fs := gotiofs.New(ctx, b)
+		fs := gotiofs.New(ctx, b.Info, &b.Volume)
 		h := http.FileServer(http.FS(fs))
 		l, err := net.Listen("tcp", *laddr)
 		if err != nil {
@@ -71,7 +71,7 @@ func newFTPCmd(open func() (*gotrepo.Repo, error)) *cobra.Command {
 		defer l.Close()
 		s, err := ftpserver.NewServer(&ftpserver.Options{
 			Auth:   ftpAuth{},
-			Driver: gotftp.NewDriver(ctx, *b),
+			Driver: gotftp.NewDriver(ctx, b.Info, b.Volume),
 			Perm:   ftpserver.NewSimplePerm("owner", "group"),
 		})
 		if err != nil {

--- a/pkg/gotcmd/branch.go
+++ b/pkg/gotcmd/branch.go
@@ -24,7 +24,7 @@ func newBranchCmd(open func() (*gotrepo.Repo, error)) *cobra.Command {
 		Args:     cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			branchName := args[0]
-			_, err := repo.CreateBranch(ctx, branchName, branches.NewMetadata(false))
+			_, err := repo.CreateBranch(ctx, branchName, branches.NewConfig(false))
 			return err
 		},
 	}
@@ -82,7 +82,7 @@ func newBranchCmd(open func() (*gotrepo.Repo, error)) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return prettyPrintJSON(cmd.OutOrStdout(), branch.Metadata)
+			return prettyPrintJSON(cmd.OutOrStdout(), branch.Info)
 		},
 	}
 	var cpSaltCmd = &cobra.Command{
@@ -93,17 +93,17 @@ func newBranchCmd(open func() (*gotrepo.Repo, error)) *cobra.Command {
 		Args:     cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			src, dst := args[0], args[1]
-			srcb, err := repo.GetBranch(ctx, src)
+			srcInfo, err := repo.GetBranch(ctx, src)
 			if err != nil {
 				return err
 			}
-			dstb, err := repo.GetBranch(ctx, dst)
+			dstInfo, err := repo.GetBranch(ctx, dst)
 			if err != nil {
 				return err
 			}
-			md := dstb.Metadata
-			md.Salt = srcb.Salt
-			return repo.SetBranch(ctx, dst, md)
+			cfg := dstInfo.AsConfig()
+			cfg.Salt = srcInfo.Salt
+			return repo.SetBranch(ctx, dst, cfg)
 		},
 	}
 	for _, c := range []*cobra.Command{

--- a/pkg/gotgrpc/convert.go
+++ b/pkg/gotgrpc/convert.go
@@ -1,0 +1,45 @@
+package gotgrpc
+
+import (
+	"github.com/brendoncarroll/go-exp/slices2"
+	"github.com/brendoncarroll/go-tai64"
+
+	"github.com/gotvc/got/pkg/branches"
+)
+
+func (bi *BranchInfo) ToInfo() *branches.Info {
+	if bi == nil {
+		return nil
+	}
+	createdAt, _ := tai64.Parse(bi.CreatedAt)
+	return &branches.Info{
+		Salt: bi.Salt,
+		Mode: branches.Mode(bi.Mode),
+		Annotations: slices2.Map(bi.Annotations, func(x *Annotation) branches.Annotation {
+			return x.ToAnnotation()
+		}),
+
+		CreatedAt: createdAt,
+	}
+}
+
+func ProtoBranchInfo(x *branches.Info) *BranchInfo {
+	return &BranchInfo{
+		Salt:        x.Salt,
+		Mode:        Mode(x.Mode),
+		Annotations: slices2.Map(x.Annotations, ProtoAnnotation),
+
+		CreatedAt: x.CreatedAt.Marshal(),
+	}
+}
+
+func (a *Annotation) ToAnnotation() branches.Annotation {
+	if a == nil {
+		return branches.Annotation{}
+	}
+	return branches.Annotation{Key: a.Key, Value: a.Value}
+}
+
+func ProtoAnnotation(x branches.Annotation) *Annotation {
+	return &Annotation{Key: x.Key, Value: x.Value}
+}

--- a/pkg/gothost/engine.go
+++ b/pkg/gothost/engine.go
@@ -166,6 +166,11 @@ func (e *HostEngine) ListIdentitiesFull(ctx context.Context) ([]IDEntry, error) 
 	return ListIdentitiesFull(ctx, e.fsop, ms, ds, *r)
 }
 
+func (e *HostEngine) CanDo(sub PeerID, verb branchintc.Verb, obj string) bool {
+	ap := e.cachedPolicy.Load()
+	return ap.CanDo(sub, verb, obj)
+}
+
 func (e *HostEngine) readFS(ctx context.Context) (ms, ds cadata.Store, root *gotfs.Root, _ error) {
 	v, err := e.inner.Open(ctx, HostConfigKey)
 	if err != nil {

--- a/pkg/gothost/engine.go
+++ b/pkg/gothost/engine.go
@@ -25,19 +25,17 @@ type HostEngine struct {
 }
 
 func NewHostEngine(inner branches.Space) *HostEngine {
-	b := &branches.Branch{
-		Metadata: branches.NewMetadata(true),
-	}
+	info := branches.NewConfig(true).AsInfo()
 	return &HostEngine{
 		inner: inner,
-		fsop:  branches.NewGotFS(b),
-		vcop:  branches.NewGotVC(b),
+		fsop:  branches.NewGotFS(&info),
+		vcop:  branches.NewGotVC(&info),
 	}
 }
 
 // Initialize creates the host config branch if it does not exist.
 func (e *HostEngine) Initialize(ctx context.Context) error {
-	md := branches.NewMetadata(true)
+	md := branches.NewConfig(true)
 	md.Annotations = append(md.Annotations, branches.Annotation{Key: "protocol", Value: "gothost@v0"})
 	_, err := branches.CreateIfNotExists(ctx, e.inner, HostConfigKey, md)
 	if err != nil {
@@ -169,11 +167,11 @@ func (e *HostEngine) ListIdentitiesFull(ctx context.Context) ([]IDEntry, error) 
 }
 
 func (e *HostEngine) readFS(ctx context.Context) (ms, ds cadata.Store, root *gotfs.Root, _ error) {
-	b, err := e.inner.Get(ctx, HostConfigKey)
+	v, err := e.inner.Open(ctx, HostConfigKey)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	snap, err := branches.GetHead(ctx, *b)
+	snap, err := branches.GetHead(ctx, *v)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -186,21 +184,21 @@ func (e *HostEngine) readFS(ctx context.Context) (ms, ds cadata.Store, root *got
 		}
 		return ms, ds, root, nil
 	}
-	return b.Volume.FSStore, b.Volume.RawStore, &snap.Root, nil
+	return v.FSStore, v.RawStore, &snap.Root, nil
 }
 
 func (e *HostEngine) modifyFS(ctx context.Context, fn func(op *gotfs.Operator, ms, ds cadata.Store, x gotfs.Root) (*gotfs.Root, error)) error {
 	defer e.reload(ctx)
-	b, err := e.inner.Get(ctx, HostConfigKey)
+	v, err := e.inner.Open(ctx, HostConfigKey)
 	if err != nil {
 		return err
 	}
 	scratch := branches.StoreTriple{
-		Raw: stores.AddWriteLayer(b.Volume.RawStore, stores.NewMem()),
-		FS:  stores.AddWriteLayer(b.Volume.FSStore, stores.NewMem()),
-		VC:  stores.AddWriteLayer(b.Volume.VCStore, stores.NewMem()),
+		Raw: stores.AddWriteLayer(v.RawStore, stores.NewMem()),
+		FS:  stores.AddWriteLayer(v.FSStore, stores.NewMem()),
+		VC:  stores.AddWriteLayer(v.VCStore, stores.NewMem()),
 	}
-	return branches.Apply(ctx, *b, scratch, func(snap *gotvc.Snapshot) (*gotvc.Snapshot, error) {
+	return branches.Apply(ctx, *v, scratch, func(snap *gotvc.Snapshot) (*gotvc.Snapshot, error) {
 		var x gotfs.Root
 		if snap != nil {
 			x = snap.Root

--- a/pkg/gothost/gothost_test.go
+++ b/pkg/gothost/gothost_test.go
@@ -19,7 +19,7 @@ func TestConfigureDefaults(t *testing.T) {
 	require.NoError(t, e.Modify(ctx, ConfigureDefaults([]PeerID{newID(t, 0)})))
 
 	s2 := e.Open(newID(t, 0))
-	_, err := s2.Create(ctx, "test", branches.NewMetadata(false))
+	_, err := s2.Create(ctx, "test", branches.NewConfig(false))
 	require.NoError(t, err)
 }
 

--- a/pkg/gotnet/cells.go
+++ b/pkg/gotnet/cells.go
@@ -93,22 +93,22 @@ func (cs *cellSrv) handleAsk(ctx context.Context, resp []byte, msg p2p.Message[P
 
 func (cs *cellSrv) handleCAS(ctx context.Context, peer PeerID, name string, actual, prev, next []byte) (int, error) {
 	space := cs.open(peer)
-	branch, err := space.Get(ctx, name)
+	v, err := space.Open(ctx, name)
 	if err != nil {
 		return 0, err
 	}
-	cell := branch.Volume.Cell
+	cell := v.Cell
 	_, n, err := cell.CAS(ctx, actual, prev, next)
 	return n, err
 }
 
 func (cs *cellSrv) handleRead(ctx context.Context, peer PeerID, name string, buf []byte) (int, error) {
 	space := cs.open(peer)
-	branch, err := space.Get(ctx, name)
+	v, err := space.Open(ctx, name)
 	if err != nil {
 		return 0, err
 	}
-	cell := branch.Volume.Cell
+	cell := v.Cell
 	return cell.Read(ctx, buf)
 }
 

--- a/pkg/gotnet/gotnet_test.go
+++ b/pkg/gotnet/gotnet_test.go
@@ -60,21 +60,21 @@ func TestCell(t *testing.T) {
 func createCell(t testing.TB, space branches.Space) cells.Cell {
 	name := "test"
 	ctx := testutil.Context(t)
-	_, err := space.Create(ctx, name, branches.Metadata{})
+	_, err := space.Create(ctx, name, branches.Config{})
 	require.NoError(t, err)
-	branch, err := space.Get(ctx, name)
+	v, err := space.Open(ctx, name)
 	require.NoError(t, err)
-	return branch.Volume.Cell
+	return v.Cell
 }
 
 func createStore(t testing.TB, space branches.Space) cadata.Store {
 	name := "test"
 	ctx := testutil.Context(t)
-	_, err := space.Create(ctx, name, branches.Metadata{})
+	_, err := space.Create(ctx, name, branches.Config{})
 	require.NoError(t, err)
-	branch, err := space.Get(ctx, name)
+	v, err := space.Open(ctx, name)
 	require.NoError(t, err)
-	return branch.Volume.RawStore
+	return v.RawStore
 }
 
 type side struct {

--- a/pkg/gotnet/store.go
+++ b/pkg/gotnet/store.go
@@ -251,11 +251,11 @@ func (s *blobMainSrv) handleGet(ctx context.Context, peer PeerID, req BlobReq, b
 		return 0, fmt.Errorf("must request exactly one blob at a time")
 	}
 	id := req.IDs[0]
-	b, err := space.Get(ctx, req.Branch)
+	vol, err := space.Open(ctx, req.Branch)
 	if err != nil {
 		return 0, err
 	}
-	store, err := getStoreFromVolume(b.Volume, req.StoreType)
+	store, err := getStoreFromVolume(*vol, req.StoreType)
 	if err != nil {
 		return 0, err
 	}
@@ -264,12 +264,11 @@ func (s *blobMainSrv) handleGet(ctx context.Context, peer PeerID, req BlobReq, b
 
 func (s *blobMainSrv) handlePost(ctx context.Context, peer PeerID, req BlobReq) (*BlobResp, error) {
 	space := s.open(peer)
-	branch, err := space.Get(ctx, req.Branch)
+	vol, err := space.Open(ctx, req.Branch)
 	if err != nil {
 		return nil, err
 	}
-	vol := branch.Volume
-	store, err := getStoreFromVolume(vol, req.StoreType)
+	store, err := getStoreFromVolume(*vol, req.StoreType)
 	if err != nil {
 		return nil, err
 	}
@@ -298,11 +297,11 @@ func (s *blobMainSrv) handlePost(ctx context.Context, peer PeerID, req BlobReq) 
 
 func (s *blobMainSrv) handleExists(ctx context.Context, peer PeerID, req BlobReq) (*BlobResp, error) {
 	space := s.open(peer)
-	branch, err := space.Get(ctx, req.Branch)
+	vol, err := space.Open(ctx, req.Branch)
 	if err != nil {
 		return nil, err
 	}
-	store, err := getStoreFromVolume(branch.Volume, req.StoreType)
+	store, err := getStoreFromVolume(*vol, req.StoreType)
 	if err != nil {
 		return nil, err
 	}
@@ -321,11 +320,11 @@ func (s *blobMainSrv) handleExists(ctx context.Context, peer PeerID, req BlobReq
 
 func (s *blobMainSrv) handleDelete(ctx context.Context, peer PeerID, req BlobReq) (*BlobResp, error) {
 	space := s.open(peer)
-	branch, err := space.Get(ctx, req.Branch)
+	vol, err := space.Open(ctx, req.Branch)
 	if err != nil {
 		return nil, err
 	}
-	store, err := getStoreFromVolume(branch.Volume, req.StoreType)
+	store, err := getStoreFromVolume(*vol, req.StoreType)
 	if err != nil {
 		return nil, err
 	}
@@ -343,11 +342,11 @@ func (s *blobMainSrv) handleDelete(ctx context.Context, peer PeerID, req BlobReq
 
 func (s *blobMainSrv) handleList(ctx context.Context, peer PeerID, req BlobReq) (*BlobResp, error) {
 	space := s.open(peer)
-	branch, err := space.Get(ctx, req.Branch)
+	vol, err := space.Open(ctx, req.Branch)
 	if err != nil {
 		return nil, err
 	}
-	store, err := getStoreFromVolume(branch.Volume, req.StoreType)
+	store, err := getStoreFromVolume(*vol, req.StoreType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gotrepo/debug.go
+++ b/pkg/gotrepo/debug.go
@@ -32,33 +32,31 @@ func (r *Repo) DebugDB(ctx context.Context, w io.Writer) error {
 }
 
 func (r *Repo) DebugFS(ctx context.Context, w io.Writer) error {
-	_, branch, err := r.GetActiveBranch(ctx)
+	_, b, err := r.GetActiveBranch(ctx)
 	if err != nil {
 		return err
 	}
-	vol := branch.Volume
-	x, err := branches.GetHead(ctx, *branch)
+	x, err := branches.GetHead(ctx, b.Volume)
 	if err != nil {
 		return err
 	}
 	if x == nil {
 		return fmt.Errorf("no snapshot, no root")
 	}
-	return gotfs.Dump(ctx, vol.FSStore, x.Root, w)
+	return gotfs.Dump(ctx, b.Volume.FSStore, x.Root, w)
 }
 
 func (r *Repo) DebugKV(ctx context.Context, w io.Writer) error {
-	_, branch, err := r.GetActiveBranch(ctx)
+	_, b, err := r.GetActiveBranch(ctx)
 	if err != nil {
 		return err
 	}
-	vol := branch.Volume
-	x, err := branches.GetHead(ctx, *branch)
+	x, err := branches.GetHead(ctx, b.Volume)
 	if err != nil {
 		return err
 	}
 	if x == nil {
 		return fmt.Errorf("no snapshot, no root")
 	}
-	return gotkv.DebugTree(ctx, vol.FSStore, x.Root.ToGotKV(), w)
+	return gotkv.DebugTree(ctx, b.Volume.FSStore, x.Root.ToGotKV(), w)
 }

--- a/pkg/gotrepo/lazyspace.go
+++ b/pkg/gotrepo/lazyspace.go
@@ -20,7 +20,7 @@ func newLazySpace(fn func(ctx context.Context) (branches.Space, error)) *lazySpa
 	return &lazySpace{newSpace: fn}
 }
 
-func (ls *lazySpace) Create(ctx context.Context, name string, params branches.Metadata) (*branches.Branch, error) {
+func (ls *lazySpace) Create(ctx context.Context, name string, params branches.Config) (*branches.Info, error) {
 	space, err := ls.getSpace(ctx)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func (ls *lazySpace) Create(ctx context.Context, name string, params branches.Me
 	return space.Create(ctx, name, params)
 }
 
-func (ls *lazySpace) Get(ctx context.Context, name string) (*branches.Branch, error) {
+func (ls *lazySpace) Get(ctx context.Context, name string) (*branches.Info, error) {
 	space, err := ls.getSpace(ctx)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (ls *lazySpace) Get(ctx context.Context, name string) (*branches.Branch, er
 	return space.Get(ctx, name)
 }
 
-func (ls *lazySpace) Set(ctx context.Context, name string, md branches.Metadata) error {
+func (ls *lazySpace) Set(ctx context.Context, name string, md branches.Config) error {
 	space, err := ls.getSpace(ctx)
 	if err != nil {
 		return err
@@ -58,6 +58,14 @@ func (ls *lazySpace) List(ctx context.Context, span branches.Span, limit int) ([
 		return nil, err
 	}
 	return space.List(ctx, span, limit)
+}
+
+func (ls *lazySpace) Open(ctx context.Context, name string) (*branches.Volume, error) {
+	space, err := ls.getSpace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return space.Open(ctx, name)
 }
 
 func (ls *lazySpace) getSpace(ctx context.Context) (branches.Space, error) {

--- a/pkg/gotrepo/porting.go
+++ b/pkg/gotrepo/porting.go
@@ -19,10 +19,10 @@ func (r *Repo) GetImportStores(ctx context.Context, branchName string) (*branche
 	if err != nil {
 		return nil, err
 	}
-	return r.getImportTriple(ctx, b)
+	return r.getImportTriple(ctx, &b.Info)
 }
 
-func (r *Repo) getImporter(ctx context.Context, b *branches.Branch) (*porting.Importer, error) {
+func (r *Repo) getImporter(ctx context.Context, b *branches.Info) (*porting.Importer, error) {
 	salt := saltFromBytes(b.Salt)
 	saltHash := gdat.Hash(salt[:])
 	st, err := r.getImportTriple(ctx, b)
@@ -34,7 +34,7 @@ func (r *Repo) getImporter(ctx context.Context, b *branches.Branch) (*porting.Im
 	return porting.NewImporter(fsop, cache, st.FS, st.Raw), nil
 }
 
-func (r *Repo) getExporter(b *branches.Branch) *porting.Exporter {
+func (r *Repo) getExporter(b *branches.Info) *porting.Exporter {
 	fsop := r.getFSOp(b)
 	salt := saltFromBytes(b.Salt)
 	saltHash := gdat.Hash(salt[:])
@@ -42,7 +42,7 @@ func (r *Repo) getExporter(b *branches.Branch) *porting.Exporter {
 	return porting.NewExporter(fsop, cache, r.workingDir)
 }
 
-func (r *Repo) getImportTriple(ctx context.Context, b *branches.Branch) (ret *branches.StoreTriple, _ error) {
+func (r *Repo) getImportTriple(ctx context.Context, b *branches.Info) (ret *branches.StoreTriple, _ error) {
 	salt := saltFromBytes(b.Salt)
 	saltHash := gdat.Hash(salt[:])
 	ids := [3]uint64{}

--- a/pkg/gotrepo/repo.go
+++ b/pkg/gotrepo/repo.go
@@ -69,7 +69,6 @@ type (
 	Cell   = cells.Cell
 	Space  = branches.Space
 	Volume = branches.Volume
-	Branch = branches.Branch
 	Store  = cadata.Store
 
 	Ref  = gotkv.Ref
@@ -208,7 +207,7 @@ func Open(p string) (*Repo, error) {
 	if r.space, err = r.spaceFromSpecs(r.config.Spaces); err != nil {
 		return nil, err
 	}
-	if _, err := branches.CreateIfNotExists(ctx, r.specDir, nameMaster, branches.NewMetadata(false)); err != nil {
+	if _, err := branches.CreateIfNotExists(ctx, r.specDir, nameMaster, branches.NewConfig(false)); err != nil {
 		return nil, err
 	}
 	r.hostEngine = gothost.NewHostEngine(r.specDir)
@@ -246,11 +245,11 @@ func (r *Repo) GetHostEngine() *gothost.HostEngine {
 	return r.hostEngine
 }
 
-func (r *Repo) getFSOp(b *branches.Branch) *gotfs.Operator {
+func (r *Repo) getFSOp(b *branches.Info) *gotfs.Operator {
 	return branches.NewGotFS(b)
 }
 
-func (r *Repo) getVCOp(b *branches.Branch) *gotvc.Operator {
+func (r *Repo) getVCOp(b *branches.Info) *gotvc.Operator {
 	return branches.NewGotVC(b)
 }
 

--- a/pkg/gotrepo/specs.go
+++ b/pkg/gotrepo/specs.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brendoncarroll/go-p2p"
 	"github.com/brendoncarroll/go-state/cells/httpcell"
-	"github.com/brendoncarroll/go-tai64"
 	"github.com/inet256/inet256/pkg/inet256"
 
 	"github.com/gotvc/got/pkg/branches"
@@ -34,10 +33,8 @@ func (r *Repo) MakeStore(spec StoreSpec) (Store, error) {
 }
 
 type BranchSpec struct {
-	Volume      VolumeSpec            `json:"volume"`
-	Salt        []byte                `json:"salt"`
-	Annotations []branches.Annotation `json:"annotations"`
-	CreatedAt   tai64.TAI64           `json:"created_at"`
+	Volume VolumeSpec `json:"volume"`
+	branches.Info
 }
 
 type VolumeSpec struct {


### PR DESCRIPTION
Cleanup the branch model so that branch metadata (branches.Info) is separate from branch volumes (branches.Volumes).
User configurable branch metadata is now in a `branches.Config` type which is used in the `branches.Space` API.