### PR TITLE
bugfix #98

### DIFF
--- a/src/gotwc/internal/staging/stage.go
+++ b/src/gotwc/internal/staging/stage.go
@@ -198,6 +198,7 @@ func (tx *Tx) Iterate(ctx context.Context, span gotkv.Span) (*Iterator, error) {
 	if err := tx.setup(ctx); err != nil {
 		return nil, err
 	}
+	tx.kvtx.Flush(ctx)
 	it := tx.kvtx.Iterate(ctx, span)
 	return &Iterator{it: it}, nil
 }


### PR DESCRIPTION
Previously, adding multiple paths in the same transaction would cause iteration to fail because the gotkv.Tx.Iterate method requires that the Tx be Flushed before iteration or it will panic. The ideal solution would be to fix this in the gotkv.Tx, but that requires significantly more work.

closes #98 