### PR TITLE
got {push, pull config} and config subcommands for setting up push/pull

### DIFF
--- a/doc/2.3_Spaces.md
+++ b/doc/2.3_Spaces.md
@@ -15,6 +15,6 @@ GotNS uses the same GotKV format as GotFS and similarly inherits encryption of a
 
 ## Syncing
 Syncing can be perfored between any two Spaces.
-The `push` and `fetch` operations perform Sync tasks on two Spaces.
+The `push` and `pull` operations perform Sync tasks on two Spaces.
 For push the destiation is some remote Space, and the source is the local Space.
-For fetch, it is the opposite; the destination is assumed to be the local Space, and the source is some remote Space.
+For pull, it is the opposite; the destination is assumed to be the local Space, and the source is some remote Space.

--- a/doc/3.0_CLI.md
+++ b/doc/3.0_CLI.md
@@ -31,7 +31,7 @@ MARKS:
   mark     manage the marks in a space and what they point at
 
 SPACES:
-  fetch  fetches marks from spaces according to the config
+  pull  pulls marks from spaces according to the config
   push   distributes marks to spaces according to the config
   space  manage namespaces
 

--- a/src/e2etest/repo_test.go
+++ b/src/e2etest/repo_test.go
@@ -97,6 +97,39 @@ func TestClone(t *testing.T) {
 	require.Contains(t, s2.ListMarks(""), "remote/origin/master")
 }
 
+func TestPullTwice(t *testing.T) {
+	ctx := testutil.Context(t)
+	s1 := gottests.NewSite(t)
+	s2 := gottests.NewSite(t)
+	go s1.Repo.Serve(ctx, testutil.PacketConn(t))
+	go s2.Repo.Serve(ctx, testutil.PacketConn(t))
+
+	s2.CreateMark(localMaster)
+	s2.CreateFile("f.txt", []byte("1\n"))
+	s2.Add("f.txt")
+	s2.Commit(gotwc.CommitParams{})
+	s2.CreateFile("f.txt", []byte("2\n"))
+	s2.Add("f.txt")
+	s2.Commit(gotwc.CommitParams{})
+
+	s2.ConfigureRepo(func(cfg gotrepo.Config) gotrepo.Config {
+		cfg.Blobcache.InProcess.CanTouch = append(cfg.Blobcache.InProcess.CanTouch, s1.Repo.BlobcachePeer())
+		return cfg
+	})
+	s2Spec, err := s2.Repo.NSVolumeSpec(ctx)
+	require.NoError(t, err)
+	require.NoError(t, s1.Repo.Configure(func(cfg gotrepo.Config) gotrepo.Config {
+		cfg.Spaces["s2"] = gotrepo.SpaceSpec{Blobcache: s2Spec}
+		cfg.AddPull(gotrepo.PullConfig{From: "s2", AddPrefix: "s2/"})
+		return cfg
+	}))
+
+	require.NoError(t, s1.Repo.Pull(ctx, nil))
+	err = s1.Repo.Pull(ctx, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot CAS")
+}
+
 func getOne[K comparable, V any](m map[K]V) K {
 	for k := range m {
 		return k

--- a/src/e2etest/repo_test.go
+++ b/src/e2etest/repo_test.go
@@ -90,8 +90,8 @@ func TestClone(t *testing.T) {
 	go s1.Repo.Serve(ctx, testutil.PacketConn(t))
 	go s2.Repo.Serve(ctx, testutil.PacketConn(t))
 
-	s1.Fetch()
-	s2.Fetch()
+	s1.Pull()
+	s2.Pull()
 
 	require.Contains(t, s1.ListMarks(""), "remote/origin/master")
 	require.Contains(t, s2.ListMarks(""), "remote/origin/master")

--- a/src/e2etest/repo_test.go
+++ b/src/e2etest/repo_test.go
@@ -97,39 +97,6 @@ func TestClone(t *testing.T) {
 	require.Contains(t, s2.ListMarks(""), "remote/origin/master")
 }
 
-func TestPullTwice(t *testing.T) {
-	ctx := testutil.Context(t)
-	s1 := gottests.NewSite(t)
-	s2 := gottests.NewSite(t)
-	go s1.Repo.Serve(ctx, testutil.PacketConn(t))
-	go s2.Repo.Serve(ctx, testutil.PacketConn(t))
-
-	s2.CreateMark(localMaster)
-	s2.CreateFile("f.txt", []byte("1\n"))
-	s2.Add("f.txt")
-	s2.Commit(gotwc.CommitParams{})
-	s2.CreateFile("f.txt", []byte("2\n"))
-	s2.Add("f.txt")
-	s2.Commit(gotwc.CommitParams{})
-
-	s2.ConfigureRepo(func(cfg gotrepo.Config) gotrepo.Config {
-		cfg.Blobcache.InProcess.CanTouch = append(cfg.Blobcache.InProcess.CanTouch, s1.Repo.BlobcachePeer())
-		return cfg
-	})
-	s2Spec, err := s2.Repo.NSVolumeSpec(ctx)
-	require.NoError(t, err)
-	require.NoError(t, s1.Repo.Configure(func(cfg gotrepo.Config) gotrepo.Config {
-		cfg.Spaces["s2"] = gotrepo.SpaceSpec{Blobcache: s2Spec}
-		cfg.AddPull(gotrepo.PullConfig{From: "s2", AddPrefix: "s2/"})
-		return cfg
-	}))
-
-	require.NoError(t, s1.Repo.Pull(ctx, nil))
-	err = s1.Repo.Pull(ctx, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot CAS")
-}
-
 func getOne[K comparable, V any](m map[K]V) K {
 	for k := range m {
 		return k

--- a/src/gdat/refs.go
+++ b/src/gdat/refs.go
@@ -126,7 +126,7 @@ func Equal(a, b Ref) bool {
 }
 
 // Copy copies the data at ref from src to dst.
-func Copy(ctx context.Context, src stores.RO, dst stores.WO, ref *Ref) error {
+func Copy(ctx context.Context, src stores.RO, dst stores.WO, ref Ref) error {
 	defer metrics.AddInt(ctx, "blob_copy", 1, "blobs")
 	return stores.Copy(ctx, src, dst, ref.CID)
 }

--- a/src/gotcmd/config.go
+++ b/src/gotcmd/config.go
@@ -1,0 +1,175 @@
+package gotcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	bcclient "blobcache.io/blobcache/client/go"
+	"github.com/gotvc/got/src/gotrepo"
+	"github.com/gotvc/got/src/gotwc"
+	"go.brendoncarroll.net/star"
+)
+
+var configCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "prints the repo and working copy configuration",
+	},
+	F: func(c star.Context) error {
+		if len(c.Extra) == 0 {
+			return printConfig(c)
+		}
+		childName := c.Extra[0]
+		rest := c.Extra[1:]
+		child, ok := configSubCmds[childName]
+		if !ok {
+			return fmt.Errorf("no command found for %q", childName)
+		}
+		return star.Run(c.Context, child, c.Env, childName, rest, c.StdIn, c.StdOut, c.StdErr)
+	},
+}
+
+var configSubCmds = map[string]star.Command{
+	"add-pull": configAddPullCmd,
+}
+
+var configAddPullCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "adds a pull task for a space",
+	},
+	Pos: []star.Positional{configSpaceNameParam},
+	F: func(c star.Context) error {
+		repo, err := openRepo()
+		if err != nil {
+			return err
+		}
+		defer repo.Close()
+		spaceName := configSpaceNameParam.Load(c)
+		return repo.Configure(func(x gotrepo.Config) gotrepo.Config {
+			return *x.AddPull(gotrepo.PullConfig{
+				From:      spaceName,
+				AddPrefix: spaceName + "/",
+			})
+		})
+	},
+}
+
+var configSpaceNameParam = &star.Required[string]{
+	PosName: "space-name",
+	Parse:   star.ParseString,
+}
+
+func printConfig(c star.Context) error {
+	workDir, err := os.OpenRoot(".")
+	if err != nil {
+		return err
+	}
+	defer workDir.Close()
+	repoCfg, err := gotrepo.LoadConfig(workDir)
+	if err != nil {
+		return err
+	}
+
+	repoDir, _ := filepath.Abs(workDir.Name())
+	c.Printf("REPO @ %s\n", repoDir)
+	if err := printRepoConfig(&c, *repoCfg); err != nil {
+		return err
+	}
+
+	wcCfg, err := gotwc.LoadConfig(workDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	wcDir, _ := filepath.Abs(workDir.Name())
+	c.Printf("\nWORKING COPY @ %s\n", wcDir)
+	c.Printf("  ID: %s\n", wcCfg.ID)
+	c.Printf("  HEAD: %s\n", wcCfg.SaveTo)
+	c.Printf("  ACT AS: %s\n", wcCfg.ActAs)
+	c.Printf("  REPO DIR: %s\n", wcCfg.RepoDir)
+	if len(wcCfg.Base) > 0 {
+		c.Printf("  BASE:\n")
+		for _, ref := range wcCfg.Base {
+			c.Printf("  | %s\n", ref.CID)
+		}
+	}
+	if len(wcCfg.Tracking) > 0 {
+		c.Printf("  TRACKING:\n")
+		for _, p := range wcCfg.Tracking {
+			c.Printf("    %s\n", p)
+		}
+	}
+
+	return nil
+}
+
+func printRepoConfig(c *star.Context, repoCfg gotrepo.Config) error {
+	c.Printf("  REPO VOLUME: %s\n", repoCfg.RepoVolume)
+	c.Printf("  BLOBCACHE:\n")
+	if err := printBlobcacheConfig(c, repoCfg.Blobcache, "    "); err != nil {
+		return err
+	}
+
+	if len(repoCfg.Identities) > 0 {
+		c.Printf("  IDENTITIES:\n")
+		for name, id := range repoCfg.Identities {
+			c.Printf("  | %-30s %s\n", name, id.Base64String()[:16]+"...")
+		}
+	}
+
+	if len(repoCfg.Spaces) > 0 {
+		c.Printf("  SPACES:\n")
+		c.Printf("    %-30s %-19s %-19s\n", "NAME", "NODE", "OID")
+		for name, spec := range repoCfg.Spaces {
+			if spec.Blobcache != nil {
+				c.Printf("  | %-30s %16s... %16s...\n",
+					name,
+					spec.Blobcache.URL.Node.Base64String()[:16],
+					spec.Blobcache.URL.Base.String()[:16],
+				)
+			}
+		}
+	}
+
+	c.Printf("  PULL TASKS:\n")
+	c.Printf("  |>%-20s %-20s %-20s %-20s\n", "FROM", "FILTER", "CUT_PREFIX", "ADD_PREFIX")
+	for _, pc := range repoCfg.Pull {
+		var filter string
+		if pc.Filter != nil {
+			filter = pc.Filter.String()
+		}
+		c.Printf("  | %-20s %-20s %-20s %-20s\n", pc.From, filter, pc.CutPrefix, pc.AddPrefix)
+	}
+
+	c.Printf("  PUSH TASKS:\n")
+	c.Printf("  |>%-20s %-20s %-20s %-20s\n", "TO", "FILTER", "CUT_PREFIX", "ADD_PREFIX")
+	for _, pc := range repoCfg.Push {
+		var filter string
+		if pc.Filter != nil {
+			filter = pc.Filter.String()
+		}
+		c.Printf("  | %-20s %-20s %-20s %-20s\n", pc.To, filter, pc.CutPrefix, pc.AddPrefix)
+	}
+	return nil
+}
+
+func printBlobcacheConfig(c *star.Context, x gotrepo.BlobcacheSpec, indent string) error {
+	switch {
+	case x.EnvClient != nil:
+		v, ok := os.LookupEnv(bcclient.EnvBlobcacheAPI)
+		if !ok {
+			v = bcclient.DefaultEndpoint + " (default)"
+		}
+		c.Printf(indent+"ENV: %v=%v\n", bcclient.EnvBlobcacheAPI, v)
+	case x.InProcess != nil:
+		ipcfg := x.InProcess
+		c.Printf(indent + "IN PROCESS\n")
+		c.Printf(indent+"ACT AS: \n", ipcfg.ActAs)
+	default:
+		c.Printf("  (EMPTY BLOBCACHE CONFIG)\n")
+	}
+	return nil
+}

--- a/src/gotcmd/config.go
+++ b/src/gotcmd/config.go
@@ -122,7 +122,7 @@ func printRepoConfig(c *star.Context, repoCfg gotrepo.Config) error {
 
 	if len(repoCfg.Spaces) > 0 {
 		c.Printf("  SPACES:\n")
-		c.Printf("    %-30s %-19s %-19s\n", "NAME", "NODE", "OID")
+		c.Printf("  | %-30s %-19s %-19s\n", "NAME", "NODE", "OID")
 		for name, spec := range repoCfg.Spaces {
 			if spec.Blobcache != nil {
 				c.Printf("  | %-30s %16s... %16s...\n",
@@ -135,21 +135,25 @@ func printRepoConfig(c *star.Context, repoCfg gotrepo.Config) error {
 	}
 
 	c.Printf("  PULL TASKS:\n")
-	c.Printf("  |>%-20s %-20s %-20s %-20s\n", "FROM", "FILTER", "CUT_PREFIX", "ADD_PREFIX")
+	c.Printf("  | %-20s %-20s %-20s %-20s\n", "FROM", "FILTER", "CUT_PREFIX", "ADD_PREFIX")
 	for _, pc := range repoCfg.Pull {
 		var filter string
 		if pc.Filter != nil {
 			filter = pc.Filter.String()
+		} else {
+			filter = "(none)"
 		}
 		c.Printf("  | %-20s %-20s %-20s %-20s\n", pc.From, filter, pc.CutPrefix, pc.AddPrefix)
 	}
 
 	c.Printf("  PUSH TASKS:\n")
-	c.Printf("  |>%-20s %-20s %-20s %-20s\n", "TO", "FILTER", "CUT_PREFIX", "ADD_PREFIX")
+	c.Printf("  | %-20s %-20s %-20s %-20s\n", "TO", "FILTER", "CUT_PREFIX", "ADD_PREFIX")
 	for _, pc := range repoCfg.Push {
 		var filter string
 		if pc.Filter != nil {
 			filter = pc.Filter.String()
+		} else {
+			filter = "(none)"
 		}
 		c.Printf("  | %-20s %-20s %-20s %-20s\n", pc.To, filter, pc.CutPrefix, pc.AddPrefix)
 	}
@@ -166,7 +170,7 @@ func printBlobcacheConfig(c *star.Context, x gotrepo.BlobcacheSpec, indent strin
 		c.Printf(indent+"ENV: %v=%v\n", bcclient.EnvBlobcacheAPI, v)
 	case x.InProcess != nil:
 		ipcfg := x.InProcess
-		c.Printf(indent + "IN PROCESS\n")
+		c.Printf("%s IN PROCESS\n", indent)
 		c.Printf(indent+"ACT AS: \n", ipcfg.ActAs)
 	default:
 		c.Printf("  (EMPTY BLOBCACHE CONFIG)\n")

--- a/src/gotcmd/config.go
+++ b/src/gotcmd/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	bcclient "blobcache.io/blobcache/client/go"
 	"github.com/gotvc/got/src/gotrepo"
@@ -31,6 +32,9 @@ var configCmd = star.Command{
 
 var configSubCmds = map[string]star.Command{
 	"add-pull": configAddPullCmd,
+	"add-push": configAddPushCmd,
+	"rm-pull":  configRmPullCmd,
+	"rm-push":  configRmPushCmd,
 }
 
 var configAddPullCmd = star.Command{
@@ -59,33 +63,127 @@ var configSpaceNameParam = &star.Required[string]{
 	Parse:   star.ParseString,
 }
 
+var configAddPushCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "adds a push task for a space",
+	},
+	Pos: []star.Positional{configSpaceNameParam},
+	Flags: map[string]star.Flag{
+		"add-prefix": configAddPrefixParam,
+	},
+	F: func(c star.Context) error {
+		repo, err := openRepo()
+		if err != nil {
+			return err
+		}
+		defer repo.Close()
+		spaceName := configSpaceNameParam.Load(c)
+		return repo.Configure(func(x gotrepo.Config) gotrepo.Config {
+			pc := gotrepo.PushConfig{
+				To: spaceName,
+			}
+			if prefix, ok := configAddPrefixParam.LoadOpt(c); ok {
+				pc.AddPrefix = prefix
+			}
+			x.Push = append(x.Push, pc)
+			return x
+		})
+	},
+}
+
+var configAddPrefixParam = &star.Optional[string]{
+	PosName:  "add-prefix",
+	ShortDoc: "prefix to add to mark names before pushing",
+	Parse:    star.ParseString,
+}
+
+var configRmPullCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "removes a pull task by index",
+	},
+	Pos: []star.Positional{configIndexParam},
+	F: func(c star.Context) error {
+		repo, err := openRepo()
+		if err != nil {
+			return err
+		}
+		defer repo.Close()
+		i := configIndexParam.Load(c)
+		return repo.Configure(func(x gotrepo.Config) gotrepo.Config {
+			if i < 0 || i >= len(x.Pull) {
+				return x
+			}
+			x.Pull = append(x.Pull[:i], x.Pull[i+1:]...)
+			return x
+		})
+	},
+}
+
+var configRmPushCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "removes a push task by index",
+	},
+	Pos: []star.Positional{configIndexParam},
+	F: func(c star.Context) error {
+		repo, err := openRepo()
+		if err != nil {
+			return err
+		}
+		defer repo.Close()
+		i := configIndexParam.Load(c)
+		return repo.Configure(func(x gotrepo.Config) gotrepo.Config {
+			if i < 0 || i >= len(x.Push) {
+				return x
+			}
+			x.Push = append(x.Push[:i], x.Push[i+1:]...)
+			return x
+		})
+	},
+}
+
+var configIndexParam = &star.Required[int]{
+	PosName:  "index",
+	ShortDoc: "the index of the task to remove",
+	Parse: func(s string) (int, error) {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid index: %q", s)
+		}
+		return i, nil
+	},
+}
+
 func printConfig(c star.Context) error {
 	workDir, err := os.OpenRoot(".")
 	if err != nil {
 		return err
 	}
 	defer workDir.Close()
+	dirpath, _ := filepath.Abs(workDir.Name())
+
+	wcCfg, err := gotwc.LoadConfig(workDir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		c.Printf("\nWORKING COPY @ %s\n", dirpath)
+		if err := printWCConfig(&c, *wcCfg); err != nil {
+			return err
+		}
+	}
+
 	repoCfg, err := gotrepo.LoadConfig(workDir)
 	if err != nil {
 		return err
 	}
-
-	repoDir, _ := filepath.Abs(workDir.Name())
-	c.Printf("REPO @ %s\n", repoDir)
+	c.Printf("REPO @ %s\n", dirpath)
 	if err := printRepoConfig(&c, *repoCfg); err != nil {
 		return err
 	}
+	return nil
+}
 
-	wcCfg, err := gotwc.LoadConfig(workDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	wcDir, _ := filepath.Abs(workDir.Name())
-	c.Printf("\nWORKING COPY @ %s\n", wcDir)
+func printWCConfig(c *star.Context, wcCfg gotwc.Config) error {
 	c.Printf("  ID: %s\n", wcCfg.ID)
 	c.Printf("  HEAD: %s\n", wcCfg.SaveTo)
 	c.Printf("  ACT AS: %s\n", wcCfg.ActAs)
@@ -102,7 +200,6 @@ func printConfig(c star.Context) error {
 			c.Printf("    %s\n", p)
 		}
 	}
-
 	return nil
 }
 

--- a/src/gotcmd/mark.go
+++ b/src/gotcmd/mark.go
@@ -200,10 +200,7 @@ var markInspectCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "prints any metadata for a bookmark",
 	},
-	Flags: map[string]star.Flag{
-		"space": spaceNameOptParam,
-	},
-	Pos: []star.Positional{markNameParam},
+	Pos: []star.Positional{fqmParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
 		repo, err := openRepo()
@@ -211,9 +208,7 @@ var markInspectCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
-		name := markNameParam.Load(c)
-		space, _ := spaceNameOptParam.LoadOpt(c)
-		fqm := gotrepo.FQM{Space: space, Name: name}
+		fqm := fqmParam.Load(c)
 		return repo.ViewMark(ctx, fqm, func(mt *gotcore.MarkTx) error {
 			return prettyPrintJSON(c.StdOut, mt.Info())
 		})
@@ -281,9 +276,7 @@ var historyCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "prints the commit log",
 	},
-	Flags: map[string]star.Flag{
-		"mark": fqmnOptParam,
-	},
+	Pos: []star.Positional{fqmnOptParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
 		wc, err := openWC()
@@ -343,6 +336,14 @@ func printcomm(bufw *bufio.Writer, ref gdat.Ref, comm gotcore.Commit) error {
 	bufw.Write([]byte(prettifyJSON(comm.Payload.Notes)))
 	fmt.Fprintln(bufw)
 	return nil
+}
+
+var fqmParam = &star.Required[gotrepo.FQM]{
+	PosName: "fqm",
+	Parse: func(s string) (gotrepo.FQM, error) {
+		return gotrepo.ParseFQName(s), nil
+	},
+	ShortDoc: "fully qualified mark name",
 }
 
 var markNameParam = &star.Required[string]{

--- a/src/gotcmd/mark.go
+++ b/src/gotcmd/mark.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/gotvc/got/src/gdat"
@@ -22,6 +23,7 @@ var markCmd = star.NewDir(
 		"create":  markCreateCmd,
 		"list":    markListCmd,
 		"del":     markDeleteCmd,
+		"delp":    markDeletePrefixCmd,
 		"inspect": markInspectCmd,
 		"as":      markAsCmd,
 		"cp":      markCpCmd,
@@ -119,6 +121,41 @@ var markDeleteCmd = star.Command{
 		name := markNameParam.Load(c)
 		spaceName, _ := spaceNameOptParam.LoadOpt(c)
 		return repo.DeleteMark(ctx, gotrepo.FQM{Space: spaceName, Name: name})
+	},
+}
+
+var markDeletePrefixCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "deletes all bookmarks with a name prefix",
+	},
+	Flags: map[string]star.Flag{
+		"space": spaceNameOptParam,
+	},
+	Pos: []star.Positional{markNamePrefixParam},
+	F: func(c star.Context) error {
+		ctx := c.Context
+		repo, err := openRepo()
+		if err != nil {
+			return err
+		}
+		defer repo.Close()
+		prefix := markNamePrefixParam.Load(c)
+		spaceName, _ := spaceNameOptParam.LoadOpt(c)
+		toDelete := []string{}
+		if err := repo.ForEachMark(ctx, spaceName, func(name string) error {
+			if strings.HasPrefix(name, prefix) {
+				toDelete = append(toDelete, name)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		for _, name := range toDelete {
+			if err := repo.DeleteMark(ctx, gotrepo.FQM{Space: spaceName, Name: name}); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 }
 
@@ -350,6 +387,12 @@ var markNameParam = &star.Required[string]{
 	PosName:  "mark_name",
 	Parse:    star.ParseString,
 	ShortDoc: "the name of a mark",
+}
+
+var markNamePrefixParam = &star.Required[string]{
+	PosName:  "name-prefix",
+	Parse:    star.ParseString,
+	ShortDoc: "prefix for mark names",
 }
 
 var srcMarkParam = &star.Required[gotrepo.FQM]{

--- a/src/gotcmd/mark.go
+++ b/src/gotcmd/mark.go
@@ -281,6 +281,9 @@ var historyCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "prints the commit log",
 	},
+	Flags: map[string]star.Flag{
+		"mark": fqmnOptParam,
+	},
 	F: func(c star.Context) error {
 		ctx := c.Context
 		wc, err := openWC()
@@ -293,11 +296,16 @@ var historyCmd = star.Command{
 		if err != nil {
 			return err
 		}
+		fqm, ok := fqmnOptParam.LoadOpt(c)
+		if !ok {
+			fqm = gotrepo.FQM{Name: bname}
+		}
+		markExpr := gotcore.CommitExpr_Mark{Space: fqm.Space, Name: fqm.Name}
 		pr, pw := io.Pipe()
 		eg := errgroup.Group{}
 		eg.Go(func() error {
 			bufw := bufio.NewWriter(pw)
-			err := repo.History(ctx, gotcore.CommitExpr_Mark{Name: bname}, func(ref gdat.Ref, comm gotrepo.Commit) error {
+			err := repo.History(ctx, markExpr, func(ref gdat.Ref, comm gotrepo.Commit) error {
 				if err := printcomm(bufw, ref, comm); err != nil {
 					return err
 				}

--- a/src/gotcmd/root.go
+++ b/src/gotcmd/root.go
@@ -41,6 +41,7 @@ var rootCmd = star.NewGroupedDir(
 		{Title: "REPO", Commands: []string{
 			"init",
 			"repo",
+			"config",
 			"serve",
 			"scrub",
 			"iden",
@@ -67,7 +68,7 @@ var rootCmd = star.NewGroupedDir(
 		{Title: "SPACES", Commands: []string{
 			"space",
 			"push",
-			"fetch",
+			"pull",
 		}},
 		{Title: "ADAPTERS", Commands: []string{
 			"http",
@@ -80,6 +81,7 @@ var rootCmd = star.NewGroupedDir(
 		}},
 	}, map[string]star.Command{
 		"init":   initCmd,
+		"config": configCmd,
 		"status": statusCmd,
 
 		// staging area commands
@@ -107,7 +109,7 @@ var rootCmd = star.NewGroupedDir(
 		"log":     historyCmd,
 
 		"space": spaceCmd,
-		"fetch": fetchCmd,
+		"pull":  pullCmd,
 		"push":  pushCmd,
 
 		// misc

--- a/src/gotcmd/space.go
+++ b/src/gotcmd/space.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"slices"
+	"strings"
 
 	bcclient "blobcache.io/blobcache/client/go"
 	"blobcache.io/blobcache/src/bcsdk"
@@ -212,12 +214,22 @@ var pullCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
+		var hadErrors bool
 		if err := repo.Pull(ctx, func(sr gotrepo.SyncResult) {
+			for _, item := range sr.Items {
+				if item.Err != nil {
+					hadErrors = true
+				}
+			}
 			printSyncResult(&c, sr)
 		}); err != nil {
 			return err
 		}
-		c.Printf("pull completed successfully\n")
+		if !hadErrors {
+			c.Printf("pull completed successfully\n")
+		} else {
+			c.Printf("pull completed with partial success.")
+		}
 		return nil
 	},
 }
@@ -234,18 +246,31 @@ var pushCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
+		var hadErrors bool
 		if err := repo.Push(ctx, func(sr gotrepo.SyncResult) {
+			for _, item := range sr.Items {
+				if item.Err != nil {
+					hadErrors = true
+				}
+			}
 			printSyncResult(&c, sr)
 		}); err != nil {
 			return err
 		}
-		c.Printf("push completed successfully\n")
+		if !hadErrors {
+			c.Printf("push completed successfully\n")
+		} else {
+			c.Printf("push completed with partial success.")
+		}
 		return nil
 	},
 }
 
 func printSyncResult(c *star.Context, sr gotrepo.SyncResult) error {
 	c.Printf("%s -> %s\n", sr.Src, sr.Dst)
+	slices.SortFunc(sr.Items, func(a, b gotcore.SyncResult) int {
+		return strings.Compare(a.Dst, b.Dst)
+	})
 	for _, res := range sr.Items {
 		switch {
 		case res.WasDeleted():
@@ -256,6 +281,7 @@ func printSyncResult(c *star.Context, sr gotrepo.SyncResult) error {
 			c.Printf("  %s -> %s\n", res.Src, res.Dst)
 		}
 	}
+	c.Printf("\n")
 	return nil
 }
 

--- a/src/gotcmd/space.go
+++ b/src/gotcmd/space.go
@@ -199,9 +199,9 @@ var spaceNameParam = &star.Required[string]{
 	},
 }
 
-var fetchCmd = star.Command{
+var pullCmd = star.Command{
 	Metadata: star.Metadata{
-		Short: "fetches marks from spaces according to the config",
+		Short: "pulls marks from spaces according to the config",
 	},
 	Pos: []star.Positional{},
 	F: func(c star.Context) error {
@@ -211,17 +211,17 @@ var fetchCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
-		if err := repo.Fetch(ctx); err != nil {
+		if err := repo.Pull(ctx); err != nil {
 			return err
 		}
-		c.Printf("All fetch tasks completed successfully\n")
+		c.Printf("pull completed successfully\n")
 		return nil
 	},
 }
 
 var pushCmd = star.Command{
 	Metadata: star.Metadata{
-		Short: "distributes marks to spaces according to the config",
+		Short: "pushes marks to spaces according to the config",
 	},
 	Pos: []star.Positional{},
 	F: func(c star.Context) error {
@@ -231,10 +231,10 @@ var pushCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
-		if err := repo.Distribute(ctx); err != nil {
+		if err := repo.Push(ctx); err != nil {
 			return err
 		}
-		c.Printf("All distribute tasks completed successfully\n")
+		c.Printf("push completed successfully\n")
 		return nil
 	},
 }

--- a/src/gotcmd/space.go
+++ b/src/gotcmd/space.go
@@ -80,7 +80,8 @@ var spaceSyncCmd = star.Command{
 			Dst:     dstSpaceParam.Load(c),
 			MapName: m,
 		}
-		return repo.SyncSpaces(ctx, task)
+		_, err = repo.SyncSpaces(ctx, task)
+		return err
 	},
 }
 
@@ -211,7 +212,9 @@ var pullCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
-		if err := repo.Pull(ctx); err != nil {
+		if err := repo.Pull(ctx, func(sr gotrepo.SyncResult) {
+			printSyncResult(&c, sr)
+		}); err != nil {
 			return err
 		}
 		c.Printf("pull completed successfully\n")
@@ -231,12 +234,29 @@ var pushCmd = star.Command{
 			return err
 		}
 		defer repo.Close()
-		if err := repo.Push(ctx); err != nil {
+		if err := repo.Push(ctx, func(sr gotrepo.SyncResult) {
+			printSyncResult(&c, sr)
+		}); err != nil {
 			return err
 		}
 		c.Printf("push completed successfully\n")
 		return nil
 	},
+}
+
+func printSyncResult(c *star.Context, sr gotrepo.SyncResult) error {
+	c.Printf("%s -> %s\n", sr.Src, sr.Dst)
+	for _, res := range sr.Items {
+		switch {
+		case res.WasDeleted():
+			c.Printf("  %s (deleted)\n", res.Dst)
+		case res.WasCreated():
+			c.Printf("  %s -> %s (created)\n", res.Src, res.Dst)
+		default:
+			c.Printf("  %s -> %s\n", res.Src, res.Dst)
+		}
+	}
+	return nil
 }
 
 var srcSpaceParam = &star.Required[string]{

--- a/src/gotfs/sync.go
+++ b/src/gotfs/sync.go
@@ -18,7 +18,7 @@ func (mach *Machine) Sync(ctx context.Context, src RO, dst WO, root Root) error 
 			if err != nil {
 				return err
 			}
-			return gdat.Copy(ctx, src.Data, dst.Data, &ext.Ref)
+			return gdat.Copy(ctx, src.Data, dst.Data, ext.Ref)
 		}
 		return nil
 	})

--- a/src/gotkv/gotkv.go
+++ b/src/gotkv/gotkv.go
@@ -128,7 +128,7 @@ func (a *Machine) Sync(ctx context.Context, src stores.RO, dst stores.WO, x Root
 		},
 		EntryFn: entryFn,
 		NodeFn: func(r Root) error {
-			return gdat.Copy(ctx, src, dst, &r.Ref)
+			return gdat.Copy(ctx, src, dst, r.Ref)
 		},
 	})
 }

--- a/src/gotns/gotns.go
+++ b/src/gotns/gotns.go
@@ -235,6 +235,9 @@ func (tx *Tx) Commit(ctx context.Context) error {
 	if tx.tx == nil {
 		return fmt.Errorf("tx is already done")
 	}
+	if err := tx.loadKV(ctx); err != nil {
+		return err
+	}
 	kvroot, err := tx.kvtx.Flush(ctx)
 	if err != nil {
 		return err

--- a/src/gotns/space.go
+++ b/src/gotns/space.go
@@ -137,22 +137,21 @@ func (s *SpaceTx) Stores() gotcore.RW {
 	}
 }
 
-func (s *SpaceTx) GetTarget(ctx context.Context, name string, dst *gdat.Ref) (bool, error) {
+func (s *SpaceTx) GetTarget(ctx context.Context, name string) (gdat.Ref, error) {
 	mstate, err := s.tx.Get(ctx, name)
 	if err != nil {
-		return false, err
+		return gdat.Ref{}, err
 	}
 	if mstate == nil {
-		return false, gotcore.ErrNotExist
+		return gdat.Ref{}, gotcore.ErrNotExist
 	}
-	if mstate.Target.IsZero() {
-		return false, nil
-	}
-	*dst = mstate.Target
-	return true, nil
+	return mstate.Target, nil
 }
 
 func (s *SpaceTx) SetTarget(ctx context.Context, name string, ref gdat.Ref) error {
+	if ref.CID.IsZero() {
+		ref = gdat.Ref{}
+	}
 	mstate, err := s.tx.Get(ctx, name)
 	if err != nil {
 		return err

--- a/src/gotrepo/config.go
+++ b/src/gotrepo/config.go
@@ -52,7 +52,7 @@ type PullConfig struct {
 	// From is the name of the space to pull from.
 	From string `json:"from"`
 	// Filter is a regexp for which marks to fetch from the source space.
-	Filter *regexp.Regexp `json:"filter"`
+	Filter *regexp.Regexp `json:"filter,omitempty"`
 	// CutPrefix is the prefix to remove from the name
 	// The zero value does not change the name at all.
 	CutPrefix string `json:"cut_prefix"`
@@ -65,7 +65,7 @@ type PullConfig struct {
 // PushConfig configures a distribution task.
 type PushConfig struct {
 	// Filter is a regexp for which marks to fetch from the local space.
-	Filter *regexp.Regexp `json:"filter"`
+	Filter *regexp.Regexp `json:"filter,omitempty"`
 	// CutPrefix is the prefix to remove from the name
 	// The zero value does not change the name at all.
 	CutPrefix string `json:"cut_prefix"`

--- a/src/gotrepo/config.go
+++ b/src/gotrepo/config.go
@@ -24,8 +24,8 @@ type Config struct {
 	// Spaces contain named mutable references (Bookmarks) to Commits
 	// They are most similar to git remotes.
 	Spaces map[string]SpaceSpec `json:"spaces"`
-	Fetch  []FetchConfig        `json:"fetch"`
-	Dist   []DistConfig         `json:"dist"`
+	Pull   []PullConfig         `json:"pull"`
+	Push   []PushConfig         `json:"push"`
 }
 
 func (c *Config) Validate() error {
@@ -42,15 +42,14 @@ func (c *Config) PutSpace(name string, spec SpaceSpec) *Config {
 	return c
 }
 
-func (c *Config) AddFetch(fc FetchConfig) *Config {
-	c.Fetch = append(c.Fetch, fc)
+func (c *Config) AddPull(fc PullConfig) *Config {
+	c.Pull = append(c.Pull, fc)
 	return c
 }
 
-// FetchConfig configures a fetch task.
-type FetchConfig struct {
+// PullConfig configures a pull task.
+type PullConfig struct {
 	// From is the name of the space to pull from.
-	// The destination space is always assumed to be the local space.
 	From string `json:"from"`
 	// Filter is a regexp for which marks to fetch from the source space.
 	Filter *regexp.Regexp `json:"filter"`
@@ -61,16 +60,11 @@ type FetchConfig struct {
 	// before inserting into the local space.
 	// The zero value does not change the name at all.
 	AddPrefix string `json:"add_prefix"`
-	// Delete is the regexp for which marks to delete from the destination space.
-	// Only names starting with AddPrefix in the destination space are considered.
-	// The regexp should match the entire name including the prefix.
-	Delete *regexp.Regexp `json:"delete"`
 }
 
-// DistConfig configures a distribution  task.
-type DistConfig struct {
-	// Filter is a regexp for which marks to fetch from the source space.
-	// In the case of distribution, the is always the local space.
+// PushConfig configures a distribution task.
+type PushConfig struct {
+	// Filter is a regexp for which marks to fetch from the local space.
 	Filter *regexp.Regexp `json:"filter"`
 	// CutPrefix is the prefix to remove from the name
 	// The zero value does not change the name at all.
@@ -81,10 +75,6 @@ type DistConfig struct {
 	AddPrefix string `json:"add_prefix"`
 	// To is the name of the space to write to.
 	To string `json:"to"`
-	// Delete is the regexp for which marks to delete from the destination space.
-	// Only names starting with AddPrefix in the destination space are considered.
-	// The regexp should match the entire name including the prefix.
-	Delete *regexp.Regexp `json:"delete"`
 }
 
 func DefaultConfig() Config {
@@ -120,11 +110,11 @@ func EditConfig(repo *os.Root, fn func(x Config) Config) error {
 			x.Spaces = map[string]SpaceSpec{}
 		}
 		// slices
-		if x.Fetch == nil {
-			x.Fetch = []FetchConfig{}
+		if x.Pull == nil {
+			x.Pull = []PullConfig{}
 		}
-		if x.Dist == nil {
-			x.Dist = []DistConfig{}
+		if x.Push == nil {
+			x.Push = []PushConfig{}
 		}
 		return fn(x)
 	})

--- a/src/gotrepo/config.go
+++ b/src/gotrepo/config.go
@@ -65,13 +65,17 @@ type PullConfig struct {
 // PushConfig configures a distribution task.
 type PushConfig struct {
 	// Filter is a regexp for which marks to fetch from the local space.
+	// If this is nil, then all names are matched.
+	// This is the first operation applied
 	Filter *regexp.Regexp `json:"filter,omitempty"`
 	// CutPrefix is the prefix to remove from the name
 	// The zero value does not change the name at all.
+	// This is the second operation applied
 	CutPrefix string `json:"cut_prefix"`
 	// AddPrefix is the prefix to add to the name
-	// before inserting into the local space.
+	// before inserting into the remote space.
 	// The zero value does not change the name at all.
+	// This is the third operation applied
 	AddPrefix string `json:"add_prefix"`
 	// To is the name of the space to write to.
 	To string `json:"to"`

--- a/src/gotrepo/marks.go
+++ b/src/gotrepo/marks.go
@@ -119,21 +119,22 @@ func (r *Repo) ViewMark(ctx context.Context, fqm FQM, fn func(*gotcore.MarkTx) e
 }
 
 // MarkLoad loads the Commit that the mark points to.
-// If the mark is empty then the commit will be nil
+// If the mark is empty then the Ref will be zeroed.
 func (r *Repo) MarkLoad(ctx context.Context, fqm FQM) (Ref, Commit, error) {
-	var exists bool
 	var ref gdat.Ref
 	var comm gotcore.Commit
 	if err := r.ViewMark(ctx, fqm, func(mt *gotcore.MarkTx) error {
-		var err error
-		exists, err = mt.Load(ctx, &ref)
-		exists, err = mt.LoadCommit(ctx, &comm)
-		return err
+		ref, err := mt.Load(ctx)
+		if err != nil {
+			return err
+		}
+		if !ref.IsZero() {
+			_, err = mt.LoadCommit(ctx, &comm)
+			return err
+		}
+		return nil
 	}); err != nil {
 		return ref, comm, err
-	}
-	if !exists {
-		return ref, comm, nil
 	}
 	return ref, comm, nil
 }

--- a/src/gotrepo/sync.go
+++ b/src/gotrepo/sync.go
@@ -53,14 +53,14 @@ type SyncSpacesTask struct {
 }
 
 // SyncSpaces executes a SyncSpaceTask
-func (r *Repo) SyncSpaces(ctx context.Context, task SyncSpacesTask) error {
+func (r *Repo) SyncSpaces(ctx context.Context, task SyncSpacesTask) ([]gotcore.SyncResult, error) {
 	srcSpace, err := r.GetSpace(ctx, task.Src)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	dstSpace, err := r.GetSpace(ctx, task.Dst)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return gotcore.SyncSpaces(ctx, gotcore.SyncSpacesTask{
 		Src:     srcSpace,
@@ -70,7 +70,15 @@ func (r *Repo) SyncSpaces(ctx context.Context, task SyncSpacesTask) error {
 	})
 }
 
-func (r *Repo) doSyncTasks(jc *gotjob.Ctx, tasks []SyncSpacesTask) error {
+type SyncResult struct {
+	// Src is the source space
+	// Dst is the destination space
+	Src, Dst string
+	// Items is each overwritten mark
+	Items []gotcore.SyncResult
+}
+
+func (r *Repo) doSyncTasks(jc *gotjob.Ctx, tasks []SyncSpacesTask, onDone func(SyncResult)) error {
 	for _, task := range tasks {
 		srcSpace, err := r.GetSpace(jc.Context, task.Src)
 		if err != nil {
@@ -81,26 +89,38 @@ func (r *Repo) doSyncTasks(jc *gotjob.Ctx, tasks []SyncSpacesTask) error {
 			return err
 		}
 		jc2 := jc.Child(fmt.Sprintf("sync-space %q -> %q", task.Src, task.Dst))
-		if err := gotcore.SyncSpaces(jc2.Context, gotcore.SyncSpacesTask{
+		res, err := gotcore.SyncSpaces(jc2.Context, gotcore.SyncSpacesTask{
 			Src:     srcSpace,
 			Dst:     dstSpace,
 			Filter:  task.Filter,
 			MapName: task.MapName,
-		}); err != nil {
+		})
+		if err != nil {
 			return err
+		}
+		if onDone != nil {
+			onDone(SyncResult{
+				Src:   task.Src,
+				Dst:   task.Dst,
+				Items: res,
+			})
 		}
 	}
 	return jc.Wait()
 }
 
-func (r *Repo) Pull(ctx context.Context) error {
+// Pull executes all pull tasks as defined in the configuration
+// Pull tasks write to the repo's local namespace.
+func (r *Repo) Pull(ctx context.Context, onDone func(SyncResult)) error {
 	var tasks []SyncSpacesTask
 	for _, fcfg := range r.config.Pull {
+		var filter func(string) bool
+		if fcfg.Filter != nil {
+			filter = fcfg.Filter.MatchString
+		}
 		tasks = append(tasks, SyncSpacesTask{
-			Src: fcfg.From,
-			Filter: func(x string) bool {
-				return fcfg.Filter.MatchString(x)
-			},
+			Src:    fcfg.From,
+			Filter: filter,
 			MapName: func(name string) string {
 				name = strings.TrimPrefix(name, fcfg.CutPrefix)
 				name = fcfg.AddPrefix + name
@@ -110,18 +130,20 @@ func (r *Repo) Pull(ctx context.Context) error {
 		})
 	}
 	jc := gotjob.New(ctx)
-	return r.doSyncTasks(&jc, tasks)
+	return r.doSyncTasks(&jc, tasks, onDone)
 }
 
 // Push is the opposite of Pull.
-func (r *Repo) Push(ctx context.Context) error {
+func (r *Repo) Push(ctx context.Context, onDone func(SyncResult)) error {
 	var tasks []SyncSpacesTask
 	for _, fcfg := range r.config.Push {
+		var filter func(string) bool
+		if fcfg.Filter != nil {
+			filter = fcfg.Filter.MatchString
+		}
 		tasks = append(tasks, SyncSpacesTask{
-			Src: "", // local space
-			Filter: func(x string) bool {
-				return fcfg.Filter.MatchString(x)
-			},
+			Src:    "", // local space
+			Filter: filter,
 			MapName: func(name string) string {
 				// this is the reverse of what we do in Pull
 				name = strings.TrimPrefix(name, fcfg.AddPrefix)
@@ -132,5 +154,5 @@ func (r *Repo) Push(ctx context.Context) error {
 		})
 	}
 	jc := gotjob.New(ctx)
-	return r.doSyncTasks(&jc, tasks)
+	return r.doSyncTasks(&jc, tasks, onDone)
 }

--- a/src/gotrepo/sync.go
+++ b/src/gotrepo/sync.go
@@ -118,6 +118,12 @@ func (r *Repo) Pull(ctx context.Context, onDone func(SyncResult)) error {
 		if fcfg.Filter != nil {
 			filter = fcfg.Filter.MatchString
 		}
+		excludePrefixes := pullExcludedPrefixes(r.config.Push, fcfg.From)
+		if len(excludePrefixes) > 0 || filter != nil {
+			filter = chainFilters(filter, func(name string) bool {
+				return !hasPrefixIn(excludePrefixes, name)
+			})
+		}
 		tasks = append(tasks, SyncSpacesTask{
 			Src:    fcfg.From,
 			Filter: filter,
@@ -141,13 +147,18 @@ func (r *Repo) Push(ctx context.Context, onDone func(SyncResult)) error {
 		if fcfg.Filter != nil {
 			filter = fcfg.Filter.MatchString
 		}
+		excludePrefixes := pushExcludedPrefixes(r.config.Pull, fcfg.To)
+		if len(excludePrefixes) > 0 || filter != nil {
+			filter = chainFilters(filter, func(name string) bool {
+				return !hasPrefixIn(excludePrefixes, name)
+			})
+		}
 		tasks = append(tasks, SyncSpacesTask{
 			Src:    "", // local space
 			Filter: filter,
 			MapName: func(name string) string {
-				// this is the reverse of what we do in Pull
-				name = strings.TrimPrefix(name, fcfg.AddPrefix)
-				name = fcfg.CutPrefix + name
+				name = strings.TrimPrefix(name, fcfg.CutPrefix)
+				name = fcfg.AddPrefix + name
 				return name
 			},
 			Dst: fcfg.To,
@@ -155,4 +166,57 @@ func (r *Repo) Push(ctx context.Context, onDone func(SyncResult)) error {
 	}
 	jc := gotjob.New(ctx)
 	return r.doSyncTasks(&jc, tasks, onDone)
+}
+
+func hasPrefixIn(prefixes []string, x string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(x, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// pullExcludes returns the set of excluded prefixes for pull
+func pullExcludedPrefixes(pcs []PushConfig, from string) (ret []string) {
+	for _, pc := range pcs {
+		if pc.To != from {
+			continue
+		}
+		if pc.AddPrefix == "" {
+			continue
+		}
+		// AddPrefix will be the prefix in the remote store, since it was
+		// added on Pull
+		ret = append(ret, pc.AddPrefix)
+	}
+	return ret
+}
+
+// pushExcludes returns the set of excluded prefixes for pull
+func pushExcludedPrefixes(pcs []PullConfig, to string) (ret []string) {
+	for _, pc := range pcs {
+		if pc.From != to {
+			continue
+		}
+		if pc.AddPrefix == "" {
+			continue
+		}
+		// AddPrefix will be the prefix in the local store, since it was
+		// added on Pull
+		ret = append(ret, pc.AddPrefix)
+	}
+	return ret
+}
+
+func chainFilters(a, b func(string) bool) func(string) bool {
+	return func(name string) bool {
+		if a != nil && !a(name) {
+			return false
+		}
+		if b != nil && !b(name) {
+			return false
+		}
+		return true
+	}
 }

--- a/src/gotrepo/sync.go
+++ b/src/gotrepo/sync.go
@@ -93,9 +93,9 @@ func (r *Repo) doSyncTasks(jc *gotjob.Ctx, tasks []SyncSpacesTask) error {
 	return jc.Wait()
 }
 
-func (r *Repo) Fetch(ctx context.Context) error {
+func (r *Repo) Pull(ctx context.Context) error {
 	var tasks []SyncSpacesTask
-	for _, fcfg := range r.config.Fetch {
+	for _, fcfg := range r.config.Pull {
 		tasks = append(tasks, SyncSpacesTask{
 			Src: fcfg.From,
 			Filter: func(x string) bool {
@@ -113,17 +113,17 @@ func (r *Repo) Fetch(ctx context.Context) error {
 	return r.doSyncTasks(&jc, tasks)
 }
 
-// Distribute is the opposite of Fetch.
-func (r *Repo) Distribute(ctx context.Context) error {
+// Push is the opposite of Pull.
+func (r *Repo) Push(ctx context.Context) error {
 	var tasks []SyncSpacesTask
-	for _, fcfg := range r.config.Dist {
+	for _, fcfg := range r.config.Push {
 		tasks = append(tasks, SyncSpacesTask{
 			Src: "", // local space
 			Filter: func(x string) bool {
 				return fcfg.Filter.MatchString(x)
 			},
 			MapName: func(name string) string {
-				// this is the reverse of what we do in Fetch
+				// this is the reverse of what we do in Pull
 				name = strings.TrimPrefix(name, fcfg.AddPrefix)
 				name = fcfg.CutPrefix + name
 				return name

--- a/src/gottests/gottests.go
+++ b/src/gottests/gottests.go
@@ -73,7 +73,7 @@ func (s *Site) Clone() Site {
 	vspec, err := s.Repo.NSVolumeSpec(ctx)
 	require.NoError(s.t, err)
 	repoCfg.PutSpace("origin", gotrepo.SpaceSpec{Blobcache: vspec})
-	repoCfg.AddFetch(gotrepo.FetchConfig{
+	repoCfg.AddPull(gotrepo.PullConfig{
 		From:      "origin",
 		Filter:    regexp.MustCompile(".*"),
 		AddPrefix: "remote/origin/",
@@ -89,9 +89,9 @@ func (s *Site) CheckAll() {
 	require.NoError(s.t, s.Repo.CheckAll(ctx))
 }
 
-func (s *Site) Fetch() {
+func (s *Site) Pull() {
 	ctx := testutil.Context(s.t)
-	require.NoError(s.t, s.Repo.Fetch(ctx))
+	require.NoError(s.t, s.Repo.Pull(ctx))
 }
 
 func (s *Site) CreateFile(p string, data []byte) {

--- a/src/gottests/gottests.go
+++ b/src/gottests/gottests.go
@@ -91,7 +91,12 @@ func (s *Site) CheckAll() {
 
 func (s *Site) Pull() {
 	ctx := testutil.Context(s.t)
-	require.NoError(s.t, s.Repo.Pull(ctx))
+	require.NoError(s.t, s.Repo.Pull(ctx, nil))
+}
+
+func (s *Site) Push() {
+	ctx := testutil.Context(s.t)
+	require.NoError(s.t, s.Repo.Push(ctx, nil))
 }
 
 func (s *Site) CreateFile(p string, data []byte) {

--- a/src/gotvc/gotvc.go
+++ b/src/gotvc/gotvc.go
@@ -61,7 +61,7 @@ func (m *Machine[T]) Sync(ctx context.Context, src stores.RO, dst stores.WO, ver
 				if err := sync(parent); err != nil {
 					return err
 				}
-				if err := gdat.Copy(ctx, src, dst, &parentRef); err != nil {
+				if err := gdat.Copy(ctx, src, dst, parentRef); err != nil {
 					return err
 				}
 			}

--- a/src/internal/gotcore/expr.go
+++ b/src/internal/gotcore/expr.go
@@ -85,11 +85,9 @@ func (se CommitExpr_Mark) GetSpace() string {
 }
 
 func (se CommitExpr_Mark) Resolve(ctx context.Context, tx SpaceTx) (gdat.Ref, error) {
-	var ref gdat.Ref
-	if ok, err := tx.GetTarget(ctx, se.Name, &ref); err != nil {
+	ref, err := tx.GetTarget(ctx, se.Name)
+	if err != nil {
 		return gdat.Ref{}, err
-	} else if !ok {
-		return gdat.Ref{}, nil
 	}
 	return ref, nil
 }

--- a/src/internal/gotcore/spaces.go
+++ b/src/internal/gotcore/spaces.go
@@ -134,7 +134,8 @@ type SpaceTx interface {
 	// SetTarget changes the mark so it points to a different commit
 	SetTarget(ctx context.Context, name string, ref gdat.Ref) error
 	// GetTarget retrieves the Commit referenced by gdat.Ref
-	GetTarget(ctx context.Context, name string, dst *gdat.Ref) (bool, error)
+	// If the name has no ref, then the zero value, and nil should be returned.
+	GetTarget(ctx context.Context, name string) (gdat.Ref, error)
 }
 
 func CreateIfNotExists(ctx context.Context, stx SpaceTx, k string, cfg Metadata) (*Info, error) {
@@ -170,11 +171,9 @@ func CloneMark(ctx context.Context, st SpaceTx, from, to string) error {
 	if _, err := st.Create(ctx, to, baseInfo.AsMetadata()); err != nil {
 		return err
 	}
-	var ref gdat.Ref
-	if ok, err := st.GetTarget(ctx, from, &ref); err != nil {
+	ref, err := st.GetTarget(ctx, from)
+	if err != nil {
 		return err
-	} else if !ok {
-		ref = gdat.Ref{}
 	}
 	return st.SetTarget(ctx, to, ref)
 }

--- a/src/internal/gotcore/spaces.go
+++ b/src/internal/gotcore/spaces.go
@@ -6,6 +6,7 @@ import (
 	"iter"
 	"regexp"
 	"runtime"
+	"sync"
 
 	"errors"
 
@@ -190,11 +191,59 @@ type SyncSpacesTask struct {
 	// If nil, then all marks are copied.
 	Filter func(string) bool
 	// MapName is applied to go from names in the Src space, to name in the Dst space.
+	// If nil, then the mark names in the src are taken as is.
 	MapName func(string) string
+	// AllowPartial allows some marks to be synced and some to error.
+	// A false value (the default) will abort the whole transaction, when 1 sync fail.
+	AllowPartial bool
 }
 
-func SyncSpaces(ctx context.Context, task SyncSpacesTask) error {
-	return task.Src.Do(ctx, false, func(src SpaceTx) error {
+type SyncResult struct {
+	// Dst is the name of the Mark in the destination space
+	Dst string
+	// Src is the name of the Mark in the source space
+	// If empty, then this was deleted in the dest.
+	Src string
+	// Created is set if the Mark did not exist in the destination space
+	Created bool
+	// Err is nil if the sync was successful, non-nil if there was a problem
+	Err error
+}
+
+func (sr SyncResult) IsOK() bool {
+	return sr.Err != nil
+}
+
+func (sr SyncResult) WasDeleted() bool {
+	return sr.Src == ""
+}
+
+func (sr SyncResult) WasCreated() bool {
+	return sr.Created
+}
+
+type SyncErr struct {
+	Src, Dst string
+	Err      error
+}
+
+func (e *SyncErr) Error() string {
+	return fmt.Sprintf("while syncing %s -> %s: %v", e.Src, e.Dst, e.Err)
+}
+
+func SyncSpaces(ctx context.Context, task SyncSpacesTask) ([]SyncResult, error) {
+	var mu sync.Mutex
+	var ret []SyncResult
+	var hadSuccess bool
+	appendResult := func(x SyncResult) {
+		mu.Lock()
+		defer mu.Unlock()
+		ret = append(ret, x)
+		if x.Err == nil {
+			hadSuccess = true
+		}
+	}
+	err := task.Src.Do(ctx, false, func(src SpaceTx) error {
 		return task.Dst.Do(ctx, true, func(dst SpaceTx) error {
 			nameMap := make(map[string]string)
 			for srcName := range src.All(ctx) {
@@ -217,18 +266,38 @@ func SyncSpaces(ctx context.Context, task SyncSpacesTask) error {
 					return err
 				}
 				md := srcMark.info.AsMetadata()
+				res := SyncResult{Dst: dstName, Src: srcName}
 				if _, err := dst.Create(ctx, dstName, md); err != nil && !IsExists(err) {
 					return err
+				} else if err == nil {
+					res.Created = true
 				}
 				dstMark, err := NewMarkTx(ctx, dst, dstName)
 				if err != nil {
 					return err
 				}
 				eg.Go(func() error {
-					return Sync(ctx, srcMark, dstMark, false)
+					if err := func() error {
+						return Sync(ctx, srcMark, dstMark, false)
+					}(); err != nil {
+						if !task.AllowPartial {
+							return &SyncErr{Src: srcName, Dst: dstName, Err: err}
+						} else {
+							res.Err = err
+						}
+					}
+					appendResult(res)
+					return nil
 				})
 			}
 			return eg.Wait()
 		})
 	})
+	if err != nil {
+		return nil, err
+	}
+	if len(ret) > 0 && !hadSuccess {
+		return ret, fmt.Errorf("all syncs had errors")
+	}
+	return ret, nil
 }

--- a/src/internal/gotcore/testsuite.go
+++ b/src/internal/gotcore/testsuite.go
@@ -168,7 +168,8 @@ func TestSync(t *testing.T, setup func(testing.TB) Space) {
 					}
 					return nil
 				}))
-				require.NoError(t, SyncSpaces(ctx, SyncSpacesTask{Src: src, Dst: dst}))
+				_, err := SyncSpaces(ctx, SyncSpacesTask{Src: src, Dst: dst})
+				require.NoError(t, err)
 				require.NoError(t, dst.Do(ctx, false, func(st SpaceTx) error {
 					for name, err := range st.All(ctx) {
 						if err != nil {

--- a/src/internal/gotcore/tx.go
+++ b/src/internal/gotcore/tx.go
@@ -165,8 +165,7 @@ func (m *MarkTx) Modify(ctx context.Context, fn func(mctx ModifyCtx) (*Commit, e
 		if err != nil {
 			return err
 		}
-		ref, err = syncCommitRef(ctx, &m.gotvc, &m.gotfs, m.RO(), m.WO(), ref)
-		if err != nil {
+		if err = syncCommitRef(ctx, &m.gotvc, &m.gotfs, m.RO(), m.WO(), ref); err != nil {
 			return err
 		}
 		yRef = ref
@@ -297,14 +296,10 @@ func Sync(ctx context.Context, src, dst *MarkTx, force bool) error {
 				return gdat.Ref{}, fmt.Errorf("cannot CAS, prev ref %v is not parent of next ref %v", x, goalRef)
 			}
 		}
-		ref, err := syncCommitRef(ctx, dst.GotVC(), dst.GotFS(), src.RO(), dst.WO(), goalRef)
-		if err != nil {
+		if err := syncCommitRef(ctx, dst.GotVC(), dst.GotFS(), src.RO(), dst.WO(), goalRef); err != nil {
 			return gdat.Ref{}, err
 		}
-		if ref != goalRef {
-			panic(fmt.Sprintf("syncCommitRef produced a different ref HAVE: %v WANT: %v", ref, goalRef))
-		}
-		return ref, nil
+		return goalRef, nil
 	})
 }
 
@@ -321,19 +316,19 @@ func History(ctx context.Context, vcmach *VCMach, s stores.RO, commRef gdat.Ref,
 
 // syncCommitRef ensures that all content reachable from Ref is in the dst store.
 // blobs are copied from the source store as needed.
-func syncCommitRef(ctx context.Context, vcmach *VCMach, fsmach *gotfs.Machine, src RO, dst WO, ref gdat.Ref) (_ gdat.Ref, err error) {
+func syncCommitRef(ctx context.Context, vcmach *VCMach, fsmach *gotfs.Machine, src RO, dst WO, ref gdat.Ref) (err error) {
 	ctx, cf := metrics.Child(ctx, "syncing gotvc")
 	defer cf()
 	comm, err := vcmach.GetVertex(ctx, src.VC, ref)
 	if err != nil {
-		return gdat.Ref{}, err
+		return err
 	}
 	if err := vcmach.Sync(ctx, src.VC, dst.VC, comm, func(payload Payload) error {
 		return fsmach.Sync(ctx, src.FS, dst.FS, payload.Snap)
 	}); err != nil {
-		return gdat.Ref{}, err
+		return err
 	}
-	return vcmach.PostVertex(ctx, dst.VC, comm)
+	return gdat.Copy(ctx, src.VC, dst.VC, ref)
 }
 
 // NewGotFS creates a new gotfs.Machine suitable for writing to the mark

--- a/src/internal/gotcore/tx.go
+++ b/src/internal/gotcore/tx.go
@@ -102,32 +102,30 @@ func (m *MarkTx) Save(ctx context.Context, ref gdat.Ref) error {
 }
 
 // Load loads a commit from the Mark
-func (b *MarkTx) Load(ctx context.Context, dst *gdat.Ref) (bool, error) {
-	return b.stx.GetTarget(ctx, b.name, dst)
+func (b *MarkTx) Load(ctx context.Context) (gdat.Ref, error) {
+	return b.stx.GetTarget(ctx, b.name)
 }
 
 func (mt *MarkTx) LoadCommit(ctx context.Context, dst *Commit) (bool, error) {
-	var ref gdat.Ref
-	if ok, err := mt.Load(ctx, &ref); err != nil {
+	if ref, err := mt.Load(ctx); err != nil {
 		return false, err
-	} else if ok {
+	} else if ref.IsZero() {
+		return false, nil
+	} else {
 		comm, err := mt.GotVC().GetVertex(ctx, mt.VCRO(), ref)
 		if err != nil {
 			return false, err
 		}
 		*dst = comm
 		return true, nil
-	} else {
-		return false, nil
 	}
 }
 
 // Apply calls fn with the Marks target Ref
 // If the mark does not yet have a target, then the ref will be 0.
 func (m *MarkTx) Apply(ctx context.Context, fn func(RW, gdat.Ref) (gdat.Ref, error)) error {
-	var yRef gdat.Ref
-	var xRef gdat.Ref
-	if _, err := m.Load(ctx, &xRef); err != nil {
+	xRef, err := m.Load(ctx)
+	if err != nil {
 		return err
 	}
 	yRef, err := fn(m.stx.Stores(), xRef)
@@ -141,10 +139,10 @@ func (m *MarkTx) Modify(ctx context.Context, fn func(mctx ModifyCtx) (*Commit, e
 	m.init()
 	ss := m.stx.Stores()
 	var comm Commit
-	var target gdat.Ref
-	if ok, err := m.stx.GetTarget(ctx, m.name, &target); err != nil {
+	target, err := m.stx.GetTarget(ctx, m.name)
+	if err != nil {
 		return err
-	} else if ok {
+	} else if !target.IsZero() {
 		comm, err = m.GotVC().GetVertex(ctx, ss.VC, target)
 		if err != nil {
 			return err
@@ -173,6 +171,7 @@ func (m *MarkTx) Modify(ctx context.Context, fn func(mctx ModifyCtx) (*Commit, e
 		}
 		yRef = ref
 	}
+	// if y == nil, the yRef will still be the zero ref here
 	return m.Save(ctx, yRef)
 }
 
@@ -268,16 +267,9 @@ func Sync(ctx context.Context, src, dst *MarkTx, force bool) error {
 		return fmt.Errorf("cannot sync volumes with different salts, must use force=true")
 	}
 	return dst.Apply(ctx, func(dsts RW, x gdat.Ref) (gdat.Ref, error) {
-		var goal Commit
-		var goalRef gdat.Ref
-		if ok, err := src.Load(ctx, &goalRef); err != nil {
+		goalRef, err := src.Load(ctx)
+		if err != nil {
 			return gdat.Ref{}, err
-		} else if ok {
-			var err error
-			goal, err = src.GotVC().GetVertex(ctx, src.VCRO(), goalRef)
-			if err != nil {
-				return gdat.Ref{}, err
-			}
 		}
 
 		switch {
@@ -293,6 +285,10 @@ func Sync(ctx context.Context, src, dst *MarkTx, force bool) error {
 			if err != nil {
 				return gdat.Ref{}, err
 			}
+			goal, err := src.GotVC().GetVertex(ctx, src.VCRO(), goalRef)
+			if err != nil {
+				return gdat.Ref{}, err
+			}
 			hasAncestor, err := vcmach.IsDescendentOf(ctx, src.VCRO(), goal, prevCommit)
 			if err != nil {
 				return gdat.Ref{}, err
@@ -304,6 +300,9 @@ func Sync(ctx context.Context, src, dst *MarkTx, force bool) error {
 		ref, err := syncCommitRef(ctx, dst.GotVC(), dst.GotFS(), src.RO(), dst.WO(), goalRef)
 		if err != nil {
 			return gdat.Ref{}, err
+		}
+		if ref != goalRef {
+			panic(fmt.Sprintf("syncCommitRef produced a different ref HAVE: %v WANT: %v", ref, goalRef))
 		}
 		return ref, nil
 	})


### PR DESCRIPTION
- `got push` executes all tasks in the push section of .got/config.
- `got pull` executes all tasks in the pull section of .got/config.
- `got config` prints the config for the working copy and repo.
- `got config add-push` and `got config add-pull` generate push/pull tasks and add them to the repo config.
- syncing now uses gdat.Copy to copy bytes exactly.  This makes syncing more robust to encoding changes.