### PR TITLE
gotcmd: several space config changes

### DIFF
--- a/doc/1.2_Got_for_the_Git_Familiar.md
+++ b/doc/1.2_Got_for_the_Git_Familiar.md
@@ -18,7 +18,7 @@ All the formats are straightforward and easy to parse; lots of spaces, newlines,
 Most criticism of Git is instead directed towards its user interface (the porcelain), which been historically confusing.
 Although it has been slowly improving, it is held back by backwards compatibility.
 Got avoids reinventing the wheel where possible.
-The main goal is to replace Git's blobs and trees, with something more scalable.
+The main goal is to replace Git's blobs and trees with something more scalable.
 There have also been some small changes to porcelain-level concepts from Git.
 
 ## Similar Models

--- a/doc/2.1_Repo.md
+++ b/doc/2.1_Repo.md
@@ -3,28 +3,24 @@
 A Repository (Repo for short) is the top level object in Got.
 
 A Repo requires the following resources
-- Access to a directory in the local filesystem
 - Access to a Volume in the [Blobcache](https://blobcache.io) service
 
 Repo's manage storage for all the data in Got.
-Repo configuration is stored in the filesystem directory.
+All Repo state including the configuration is stored in Blobcache.
 Cryptographic private keys are also stored in the filesystem.
 [Blobcache](https://blobcache.io) (a local storage service) is used to hold all the file content.
 Got can be configured to use the system's Blobcache, or it can self-host a Blobcache instance in-process.
 
-A Got directory is considered a Repo if it contains a subdirectory `.got` and the regular file `.got/config` exists and contains a valid Got configuration.
-
-The Got command line tool assumes that the process's current directory is a Repo or [Working Copy](./2.2_Working_Copy.md).
+The Got command line tool assumes that the process's current directory [Working Copy](./2.2_Working_Copy.md), and uses the Working Copy config to find the repo in Blobcache.
 
 ## Volumes
 The Blobcache service organizes storage into Volumes.
 Each Got Repo has a Volume where the contents are stored in plaintext.
 This volume, called the "repo volume" primarily stores access tokens for other Volumes in Blobcache.
-When a Blobcache Volume contains an access token for another Volume.
-Those Volumes are considered linked, and the Volume being referenced by the access token is the subvolume, or child volume.
+When a Blobcache Volume contains an access token for another Volume, those Volumes are considered linked, and the Volume being referenced by the access token is the subvolume, or child volume.
 The Volume holding the access token is called the parent Volume.
 
-Got repos manage access to many subvolumes.
+Got Repos manage access to many subvolumes.
 There is a subvolume for the local Space.
 There is a subvolume per Stage; you can read about Stages in the next section.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gotvc/got
 go 1.26.0
 
 require (
-	blobcache.io/blobcache v0.7.1-0.20260612234922-1e0699a6e39a
+	blobcache.io/blobcache v0.7.1-0.20260622234859-8bc20163d91a
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	charm.land/bubbletea/v2 v2.0.2
 	github.com/cloudflare/circl v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gotvc/got
 go 1.26.0
 
 require (
-	blobcache.io/blobcache v0.7.1-0.20260623170603-568b88de5626
+	blobcache.io/blobcache v0.7.1-0.20260624003349-fb7b9b698a17
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	charm.land/bubbletea/v2 v2.0.2
 	github.com/cloudflare/circl v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gotvc/got
 go 1.26.0
 
 require (
-	blobcache.io/blobcache v0.7.1-0.20260622234859-8bc20163d91a
+	blobcache.io/blobcache v0.7.1-0.20260623170603-568b88de5626
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	charm.land/bubbletea/v2 v2.0.2
 	github.com/cloudflare/circl v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-blobcache.io/blobcache v0.7.1-0.20260612234922-1e0699a6e39a h1:l6dFWhEKx8IPhes2YV8mDERslMXWFr08M5L69JcXS14=
-blobcache.io/blobcache v0.7.1-0.20260612234922-1e0699a6e39a/go.mod h1:O/TcnF7BGLizwJmOhTQpHk0IKY5zVObcN1SM8g6h7lE=
+blobcache.io/blobcache v0.7.1-0.20260622234859-8bc20163d91a h1:EUnl75/wwc+ynI4xSbr4tK658od8pDRxRy4kLqY+PEQ=
+blobcache.io/blobcache v0.7.1-0.20260622234859-8bc20163d91a/go.mod h1:O/TcnF7BGLizwJmOhTQpHk0IKY5zVObcN1SM8g6h7lE=
 blobcache.io/glfs v0.0.0-20260606153950-599b6585abc8 h1:wS42eNh4dk/UmPjYGysQy+TCbcebn/TxqoiQ6pjgaVw=
 blobcache.io/glfs v0.0.0-20260606153950-599b6585abc8/go.mod h1:OCei1R79O+Lj/o0eoHFQCaYBhGwDrWWyZXq/cZuyQZ8=
 capnproto.org/go/capnp/v3 v3.1.0-alpha.2 h1:93ISpqHf2/3WQlfrBP0tT8Dg/RQc3uq6DV36vN0ePWk=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-blobcache.io/blobcache v0.7.1-0.20260623170603-568b88de5626 h1:kLXEHmjPjk0HdDYAz7OpnUkf1uLkjCiH2lY0/GM5ips=
-blobcache.io/blobcache v0.7.1-0.20260623170603-568b88de5626/go.mod h1:O/TcnF7BGLizwJmOhTQpHk0IKY5zVObcN1SM8g6h7lE=
+blobcache.io/blobcache v0.7.1-0.20260624003349-fb7b9b698a17 h1:UogXRvNqWhTJXG6nq97dF9VJaYCll+XTKGSgVpYepjI=
+blobcache.io/blobcache v0.7.1-0.20260624003349-fb7b9b698a17/go.mod h1:O/TcnF7BGLizwJmOhTQpHk0IKY5zVObcN1SM8g6h7lE=
 blobcache.io/glfs v0.0.0-20260606153950-599b6585abc8 h1:wS42eNh4dk/UmPjYGysQy+TCbcebn/TxqoiQ6pjgaVw=
 blobcache.io/glfs v0.0.0-20260606153950-599b6585abc8/go.mod h1:OCei1R79O+Lj/o0eoHFQCaYBhGwDrWWyZXq/cZuyQZ8=
 capnproto.org/go/capnp/v3 v3.1.0-alpha.2 h1:93ISpqHf2/3WQlfrBP0tT8Dg/RQc3uq6DV36vN0ePWk=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-blobcache.io/blobcache v0.7.1-0.20260622234859-8bc20163d91a h1:EUnl75/wwc+ynI4xSbr4tK658od8pDRxRy4kLqY+PEQ=
-blobcache.io/blobcache v0.7.1-0.20260622234859-8bc20163d91a/go.mod h1:O/TcnF7BGLizwJmOhTQpHk0IKY5zVObcN1SM8g6h7lE=
+blobcache.io/blobcache v0.7.1-0.20260623170603-568b88de5626 h1:kLXEHmjPjk0HdDYAz7OpnUkf1uLkjCiH2lY0/GM5ips=
+blobcache.io/blobcache v0.7.1-0.20260623170603-568b88de5626/go.mod h1:O/TcnF7BGLizwJmOhTQpHk0IKY5zVObcN1SM8g6h7lE=
 blobcache.io/glfs v0.0.0-20260606153950-599b6585abc8 h1:wS42eNh4dk/UmPjYGysQy+TCbcebn/TxqoiQ6pjgaVw=
 blobcache.io/glfs v0.0.0-20260606153950-599b6585abc8/go.mod h1:OCei1R79O+Lj/o0eoHFQCaYBhGwDrWWyZXq/cZuyQZ8=
 capnproto.org/go/capnp/v3 v3.1.0-alpha.2 h1:93ISpqHf2/3WQlfrBP0tT8Dg/RQc3uq6DV36vN0ePWk=

--- a/src/e2etest/repo_test.go
+++ b/src/e2etest/repo_test.go
@@ -47,7 +47,7 @@ func TestMultiRepoSync(t *testing.T) {
 
 	// configure other repos to use it.
 	for _, s := range sites[1:] {
-		err := s.Repo.Configure(ctx, func(x gotrepo.Config) gotrepo.Config {
+		s.ConfigureRepo(ctx, func(x gotrepo.Config) gotrepo.Config {
 			x.Spaces["origin"] = gotrepo.SpaceSpec{Blobcache: originSpec}
 			return x
 		})

--- a/src/gotcmd/adapters.go
+++ b/src/gotcmd/adapters.go
@@ -23,7 +23,7 @@ var httpCmd = star.Command{
 	},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,7 @@ var ftpCmd = star.Command{
 	},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}

--- a/src/gotcmd/bc.go
+++ b/src/gotcmd/bc.go
@@ -1,0 +1,68 @@
+package gotcmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+
+	bcclient "blobcache.io/blobcache/client/go"
+	"blobcache.io/blobcache/src/bcsdk"
+	"blobcache.io/blobcache/src/blobcache"
+	"blobcache.io/blobcache/src/schema/bcns"
+	"github.com/gotvc/got/src/gotns"
+	"github.com/gotvc/got/src/gotrepo"
+	"go.brendoncarroll.net/star"
+)
+
+var blobcacheCmd = star.NewDir(
+	star.Metadata{Short: "manage blobcache"},
+	map[string]star.Command{
+		"create-space": bcCreateSpaceCmd,
+	},
+)
+
+var bcCreateSpaceCmd = star.Command{
+	Metadata: star.Metadata{Short: "create a space volume. Does not modify repo config"},
+	Pos:      []star.Positional{volNameParam},
+	F: func(c star.Context) error {
+		ctx := c.Context
+		bc := bcclient.NewClientFromEnv()
+		bcns, err := bcclient.NewNSClientFromEnv()
+		if err != nil {
+			return err
+		}
+		p := volNameParam.Load(c)
+		volh, err := bcns.CreateVolume(ctx, p, gotns.SpaceVolumeSpec())
+		if err != nil {
+			return err
+		}
+		c.Printf("created volume at %s\n", p)
+		u, err := bcsdk.URLFor(ctx, bc, volh)
+		if err != nil {
+			return err
+		}
+		var secret [32]byte
+		rand.Read(secret[:])
+		c.Printf("URL: %v\n", u)
+		c.Printf("SECRET: %v\n", hex.EncodeToString(secret[:]))
+		return err
+	},
+}
+
+// createVol create a new volume according to spec at volname in the namespace
+func createVol(ctx context.Context, svc blobcache.Service, volName string, spec blobcache.VolumeSpec) (blobcache.Handle, error) {
+	root, err := bcclient.EnvNSRoot()
+	if err != nil {
+		return blobcache.Handle{}, err
+	}
+	nsc := bcns.NewClient(svc, root)
+	return nsc.CreateVolume(ctx, volName, spec)
+}
+
+func createRepoVol(ctx context.Context, svc blobcache.Service, volName string) (blobcache.Handle, error) {
+	return createVol(ctx, svc, volName, gotrepo.RepoVolumeSpec(false))
+}
+
+func createNSVol(ctx context.Context, svc blobcache.Service, volName string) (blobcache.Handle, error) {
+	return createVol(ctx, svc, volName, gotns.SpaceVolumeSpec())
+}

--- a/src/gotcmd/config.go
+++ b/src/gotcmd/config.go
@@ -92,6 +92,11 @@ func printWCConfig(c *star.Context, wcCfg gotwc.Config, indent string) error {
 }
 
 func printRepoConfig(c *star.Context, repoCfg gotrepo.Config, indent string) error {
+	if envRepo, envRepoOk := os.LookupEnv(EnvGotRepo); envRepoOk {
+		c.Printf("%sGOT_REPO=%s\n", indent, envRepo)
+	} else {
+		c.Printf("%sGOT_REPO= (not set)\n", indent)
+	}
 	if len(repoCfg.Identities) > 0 {
 		c.Printf("%sIDENTITIES:\n", indent)
 		for name, id := range repoCfg.Identities {

--- a/src/gotcmd/config.go
+++ b/src/gotcmd/config.go
@@ -108,7 +108,7 @@ func printRepoConfig(c *star.Context, repoCfg gotrepo.Config, indent string) err
 					indent,
 					name,
 					spec.Blobcache.URL.Node.Base64String()[:16],
-					spec.Blobcache.URL.Base.String()[:16],
+					spec.Blobcache.URL.OID.String()[:16],
 				)
 			}
 		}

--- a/src/gotcmd/config.go
+++ b/src/gotcmd/config.go
@@ -52,7 +52,7 @@ func printConfig(c star.Context) error {
 	}
 	c.Printf("%s\n\n", "|"+strings.Repeat("_", 40))
 
-	repo, closer, err := openRepo()
+	repo, closer, err := openRepo(c)
 	if err != nil {
 		return err
 	}

--- a/src/gotcmd/fix.go
+++ b/src/gotcmd/fix.go
@@ -25,7 +25,7 @@ var fixCmd = star.Command{
 		dst := newMarkNameParam.Load(c)
 		fixName := fixNameParam.Load(c)
 
-		r, close, err := openRepo()
+		r, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}

--- a/src/gotcmd/iden.go
+++ b/src/gotcmd/iden.go
@@ -18,7 +18,7 @@ var idenListCmd = star.Command{
 		Short: "list the identities available in the repo",
 	},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}

--- a/src/gotcmd/init.go
+++ b/src/gotcmd/init.go
@@ -43,7 +43,7 @@ var initCmd = star.Command{
 		if err := gotwc.Init(root, gotwc.DefaultConfig()); err != nil {
 			return err
 		}
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if _, err := repo.CreateMark(c, gotrepo.FQM{Name: "master"}, gotcore.DefaultConfig(false), nil); err != nil {
 			return err
 		}

--- a/src/gotcmd/mark.go
+++ b/src/gotcmd/mark.go
@@ -45,7 +45,7 @@ var markCreateCmd = star.Command{
 	Pos: []star.Positional{markNameParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ var markDeleteCmd = star.Command{
 	Pos: []star.Positional{markNameParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ var markDeletePrefixCmd = star.Command{
 	Pos: []star.Positional{markNamePrefixParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ var markMvCmd = star.Command{
 	Pos: []star.Positional{srcMarkNameParam, dstMarkNameParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ var markCpCmd = star.Command{
 	Pos: []star.Positional{srcMarkParam, dstMarkParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -215,7 +215,7 @@ var markLoadCmd = star.Command{
 	Pos: []star.Positional{markNameParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ var markInspectCmd = star.Command{
 	Pos: []star.Positional{fqmParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -259,7 +259,7 @@ var markCpSaltCmd = star.Command{
 	Pos: []star.Positional{srcMarkParam, dstMarkParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -437,7 +437,7 @@ var markSyncCmd = star.Command{
 	},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}

--- a/src/gotcmd/repo.go
+++ b/src/gotcmd/repo.go
@@ -1,8 +1,11 @@
 package gotcmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"strconv"
 
 	bcclient "blobcache.io/blobcache/client/go"
@@ -22,6 +25,7 @@ var repoCmd = star.NewDir(star.Metadata{
 	"add-pull":     repoAddPullCmd,
 	"rm-push":      repoRmPushCmd,
 	"rm-pull":      repoRmPullCmd,
+	"edit":         repoEditCmd,
 })
 
 var repoInitCmd = star.Command{
@@ -46,6 +50,67 @@ var repoInitCmd = star.Command{
 		c.Printf("repo initialized successfully")
 		return nil
 	},
+}
+
+var repoEditCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "edit the repo config in your editor",
+	},
+	F: func(c star.Context) error {
+		repo, close, err := openRepo(c)
+		if err != nil {
+			return err
+		}
+		defer close()
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			editor = "vi"
+		}
+		if err := repo.Configure(c, func(x gotrepo.Config) (gotrepo.Config, error) {
+			if err := userEdit(c.Context, &x, editor); err != nil {
+				return x, err
+			}
+			return x, nil
+		}); err != nil {
+			return err
+		}
+		c.Printf("config saved successfully\n")
+		return nil
+	},
+}
+
+func userEdit[T any](ctx context.Context, x *T, editor string) error {
+	data, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp("", "got-edit-*.json")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	for {
+		cmd := exec.Command(editor, f.Name())
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("editor: %w", err)
+		}
+		data, err := os.ReadFile(f.Name())
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, x); err != nil {
+			fmt.Fprintf(os.Stderr, "invalid JSON: %v\n", err)
+			continue
+		}
+		return nil
+	}
 }
 
 var repoCreateCmd = star.Command{
@@ -139,11 +204,11 @@ var repoAddPullCmd = star.Command{
 		}
 		defer close()
 		spaceName := configSpaceNameParam.Load(c)
-		return repo.Configure(c, func(x gotrepo.Config) gotrepo.Config {
+		return repo.Configure(c, func(x gotrepo.Config) (gotrepo.Config, error) {
 			return *x.AddPull(gotrepo.PullConfig{
 				From:      spaceName,
 				AddPrefix: spaceName + "/",
-			})
+			}), nil
 		})
 	},
 }
@@ -168,7 +233,7 @@ var repoAddPushCmd = star.Command{
 		}
 		defer close()
 		spaceName := configSpaceNameParam.Load(c)
-		return repo.Configure(c, func(x gotrepo.Config) gotrepo.Config {
+		return repo.Configure(c, func(x gotrepo.Config) (gotrepo.Config, error) {
 			pc := gotrepo.PushConfig{
 				To: spaceName,
 			}
@@ -176,7 +241,7 @@ var repoAddPushCmd = star.Command{
 				pc.AddPrefix = prefix
 			}
 			x.Push = append(x.Push, pc)
-			return x
+			return x, nil
 		})
 	},
 }
@@ -193,12 +258,12 @@ var repoRmPullCmd = star.Command{
 		}
 		defer close()
 		i := taskIndexParam.Load(c)
-		return repo.Configure(c, func(x gotrepo.Config) gotrepo.Config {
+		return repo.Configure(c, func(x gotrepo.Config) (gotrepo.Config, error) {
 			if i < 0 || i >= len(x.Pull) {
-				return x
+				return x, nil
 			}
 			x.Pull = append(x.Pull[:i], x.Pull[i+1:]...)
-			return x
+			return x, nil
 		})
 	},
 }
@@ -215,12 +280,12 @@ var repoRmPushCmd = star.Command{
 		}
 		defer close()
 		i := taskIndexParam.Load(c)
-		return repo.Configure(c, func(x gotrepo.Config) gotrepo.Config {
+		return repo.Configure(c, func(x gotrepo.Config) (gotrepo.Config, error) {
 			if i < 0 || i >= len(x.Push) {
-				return x
+				return x, nil
 			}
 			x.Push = append(x.Push[:i], x.Push[i+1:]...)
-			return x
+			return x, nil
 		})
 	},
 }

--- a/src/gotcmd/repo.go
+++ b/src/gotcmd/repo.go
@@ -96,7 +96,7 @@ var scrubCmd = star.Command{
 	},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ var repairLinksCmd = star.Command{
 		Short: "repairs repo volume link tokens",
 	},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ var repoAddPullCmd = star.Command{
 	},
 	Pos: []star.Positional{configSpaceNameParam},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ var repoAddPushCmd = star.Command{
 		"add-prefix": addPrefixParam,
 	},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ var repoRmPullCmd = star.Command{
 	},
 	Pos: []star.Positional{taskIndexParam},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -209,7 +209,7 @@ var repoRmPushCmd = star.Command{
 	},
 	Pos: []star.Positional{taskIndexParam},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}

--- a/src/gotcmd/repo.go
+++ b/src/gotcmd/repo.go
@@ -1,7 +1,6 @@
 package gotcmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -9,8 +8,6 @@ import (
 	bcclient "blobcache.io/blobcache/client/go"
 	"blobcache.io/blobcache/src/blobcache"
 	_ "blobcache.io/blobcache/src/blobcachecmd"
-	"blobcache.io/blobcache/src/schema/bcns"
-	"github.com/gotvc/got/src/gotns"
 	"github.com/gotvc/got/src/gotrepo"
 	"go.brendoncarroll.net/star"
 )
@@ -35,15 +32,15 @@ var repoInitCmd = star.Command{
 	F: func(c star.Context) error {
 		ctx := c.Context
 		bc := bcclient.NewClientFromEnv()
-		nsVol, nsc, err := bcclient.OpenNSRoot(ctx, bc)
+		nsc, err := bcclient.NewNSClientFromEnv()
 		if err != nil {
 			return err
 		}
-		volh, err := bcns.Lookup(ctx, nsc, *nsVol, volNameParam.Load(c))
+		volh, err := nsc.Open(ctx, volNameParam.Load(c), blobcache.Action_ALL)
 		if err != nil {
 			return err
 		}
-		if err := gotrepo.Init(ctx, bc, *volh, gotrepo.DefaultConfig()); err != nil {
+		if err := gotrepo.Init(ctx, bc, volh, gotrepo.DefaultConfig()); err != nil {
 			return err
 		}
 		c.Printf("repo initialized successfully")
@@ -75,11 +72,11 @@ var repoCreateCmd = star.Command{
 		}
 		c.Printf("Successfully created a new volume in the ns root\n")
 		c.Printf("NODE: %v", ep.Node)
-		c.Printf("HANDLE: %v\n", *volh)
+		c.Printf("HANDLE: %v\n", volh)
 		c.Printf("INFO: %s\n", prettifyJSON(specJSON))
 
 		c.Printf("initializing volume...\n")
-		if err := gotrepo.Init(ctx, svc, *volh, gotrepo.DefaultConfig()); err != nil {
+		if err := gotrepo.Init(ctx, svc, volh, gotrepo.DefaultConfig()); err != nil {
 			return err
 		}
 		c.Printf("successfully initialized Repo in %v", volh.OID)
@@ -238,27 +235,4 @@ var taskIndexParam = &star.Required[int]{
 		}
 		return i, nil
 	},
-}
-
-var blobcacheCmd = star.NewDir(
-	star.Metadata{Short: "manage blobcache"},
-	map[string]star.Command{},
-)
-
-// createVol create a new volume according to spec at volname in the namespace
-func createVol(ctx context.Context, svc blobcache.Service, volName string, spec blobcache.VolumeSpec) (*blobcache.Handle, error) {
-	nsh, nsc, err := bcclient.OpenNSRoot(ctx, svc)
-	if err != nil {
-		return nil, err
-	}
-	defer svc.Drop(ctx, *nsh)
-	return nsc.CreateAt(ctx, *nsh, volName, spec)
-}
-
-func createRepoVol(ctx context.Context, svc blobcache.Service, volName string) (*blobcache.Handle, error) {
-	return createVol(ctx, svc, volName, gotrepo.RepoVolumeSpec(false))
-}
-
-func createNSVol(ctx context.Context, svc blobcache.Service, volName string) (*blobcache.Handle, error) {
-	return createVol(ctx, svc, volName, gotns.DefaultVolumeSpec())
 }

--- a/src/gotcmd/root.go
+++ b/src/gotcmd/root.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"runtime/debug"
 
+	bcclient "blobcache.io/blobcache/client/go"
+	"blobcache.io/blobcache/src/blobcache"
 	"go.brendoncarroll.net/star"
 	"go.brendoncarroll.net/stdctx/logctx"
 	"go.uber.org/zap"
@@ -126,8 +128,34 @@ var rootCmd = star.NewGroupedDir(
 	},
 )
 
-func openRepo() (*gotrepo.Repo, func() error, error) {
-	wc, err := openWC()
+const (
+	EnvGotRepo = "GOT_REPO"
+)
+
+func openRepo(ctx context.Context) (*gotrepo.Repo, func() error, error) {
+	r, err := os.OpenRoot(".")
+	if err != nil {
+		return nil, nil, err
+	}
+	if yes, err := gotwc.IsWC(r); err != nil {
+		return nil, nil, err
+	} else if !yes {
+		val, ok := os.LookupEnv(EnvGotRepo)
+		if !ok {
+			return nil, nil, fmt.Errorf("not in a working copy and %s not set.", EnvGotRepo)
+		}
+		repoOID, err := blobcache.ParseOID(val)
+		if err != nil {
+			return nil, nil, err
+		}
+		bc := bcclient.NewClientFromEnv()
+		repo, err := gotrepo.Open(ctx, bc, repoOID, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return repo, func() error { return nil }, nil
+	}
+	wc, err := gotwc.Open(r)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/src/gotcmd/space.go
+++ b/src/gotcmd/space.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	bcclient "blobcache.io/blobcache/client/go"
 	"blobcache.io/blobcache/src/bcsdk"
 	"blobcache.io/blobcache/src/blobcache"
 	"github.com/gotvc/got/src/gdat"
@@ -19,10 +18,10 @@ import (
 var spaceCmd = star.NewDir(star.Metadata{
 	Short: "manage namespaces",
 }, map[string]star.Command{
-	"list":      spaceListCmd,
-	"create-bc": spaceCreateBcCmd,
-	"add-bc":    spaceAddBcCmd,
-	"sync":      spaceSyncCmd,
+	"list": spaceListCmd,
+	"add":  spaceAddCmd,
+	"rm":   spaceRmCmd,
+	"sync": spaceSyncCmd,
 })
 
 var spaceListCmd = star.Command{
@@ -42,7 +41,7 @@ var spaceListCmd = star.Command{
 			var oid blobcache.OID
 			switch {
 			case scfg.Blobcache != nil:
-				oid = scfg.Blobcache.URL.Base
+				oid = scfg.Blobcache.URL.OID
 			default:
 				c.Printf("ERROR: don't know how to print %v\n", scfg)
 				continue
@@ -94,43 +93,27 @@ var addPrefixParam = &star.Optional[string]{
 	Parse:    star.ParseString,
 }
 
-var spaceCreateBcCmd = star.Command{
+var spaceRmCmd = star.Command{
 	Metadata: star.Metadata{
-		Short: "create a new space backed by a Blobcache Volume",
+		Short: "remove a space from the repo. (DESTRUCTIVE)",
 	},
 	Pos: []star.Positional{spaceNameParam},
-	Flags: map[string]star.Flag{
-		"mkvol": volNameParam,
-	},
 	F: func(c star.Context) error {
 		repo, close, err := openRepo()
 		if err != nil {
 			return err
 		}
 		defer close()
-		bcsvc := bcclient.NewClientFromEnv()
-		ep, err := bcsvc.Endpoint(c)
-		if err != nil {
+		name := spaceNameParam.Load(c)
+		if err := repo.RemoveSpace(c, name); err != nil {
 			return err
 		}
-		volname := volNameParam.Load(c)
-		h, err := createNSVol(c, bcsvc, volname)
-		if err != nil {
-			return err
-		}
-		return repo.CreateSpace(c, spaceNameParam.Load(c), gotrepo.SpaceSpec{
-			Blobcache: &gotrepo.VolumeSpec{
-				URL: blobcache.URL{
-					Node: ep.Node,
-					Base: h.OID,
-				},
-				Secret: randomSecret(),
-			},
-		})
+		c.Printf("removed space %s successfully\n", name)
+		return nil
 	},
 }
 
-var spaceAddBcCmd = star.Command{
+var spaceAddCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "adds an existing Space backed by a Blobcache Volume",
 	},
@@ -145,7 +128,7 @@ var spaceAddBcCmd = star.Command{
 			return err
 		}
 		defer close()
-		bc := bcclient.NewClientFromEnv()
+		bc := repo.Blobcache()
 		u := bcURLParam.Load(c)
 		volh, err := bcsdk.OpenURL(c, bc, u)
 		if err != nil {
@@ -156,7 +139,7 @@ var spaceAddBcCmd = star.Command{
 		if err != nil {
 			return err
 		}
-		return repo.CreateSpace(c, spaceNameParam.Load(c), gotrepo.SpaceSpec{
+		return repo.AddSpace(c, spaceNameParam.Load(c), gotrepo.SpaceSpec{
 			Blobcache: &gotrepo.VolumeSpec{
 				URL:    u,
 				Secret: secretParam.Load(c),

--- a/src/gotcmd/space.go
+++ b/src/gotcmd/space.go
@@ -21,13 +21,14 @@ var spaceCmd = star.NewDir(star.Metadata{
 	"list": spaceListCmd,
 	"add":  spaceAddCmd,
 	"rm":   spaceRmCmd,
+	"mv":   spaceMvCmd,
 	"sync": spaceSyncCmd,
 })
 
 var spaceListCmd = star.Command{
 	Metadata: star.Metadata{Short: "list namespaces"},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -66,7 +67,7 @@ var spaceSyncCmd = star.Command{
 	Pos: []star.Positional{srcSpaceParam, dstSpaceParam},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -99,7 +100,7 @@ var spaceRmCmd = star.Command{
 	},
 	Pos: []star.Positional{spaceNameParam},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -113,6 +114,23 @@ var spaceRmCmd = star.Command{
 	},
 }
 
+var spaceMvCmd = star.Command{
+	Metadata: star.Metadata{
+		Short: "rename a space",
+	},
+	Pos: []star.Positional{spaceNameParam, newSpaceNameParam},
+	F: func(c star.Context) error {
+		repo, close, err := openRepo(c)
+		if err != nil {
+			return err
+		}
+		defer close()
+		oldName := spaceNameParam.Load(c)
+		newName := newSpaceNameParam.Load(c)
+		return repo.RenameSpace(c, oldName, newName)
+	},
+}
+
 var spaceAddCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "adds an existing Space backed by a Blobcache Volume",
@@ -123,7 +141,7 @@ var spaceAddCmd = star.Command{
 		"secret": secretParam,
 	},
 	F: func(c star.Context) error {
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -188,6 +206,16 @@ var spaceNameParam = &star.Required[string]{
 	},
 }
 
+var newSpaceNameParam = &star.Required[string]{
+	PosName: "new-name",
+	Parse: func(x string) (string, error) {
+		if err := gotcore.CheckName(x); err != nil {
+			return "", err
+		}
+		return x, nil
+	},
+}
+
 var pullCmd = star.Command{
 	Metadata: star.Metadata{
 		Short: "pulls marks from spaces according to the config",
@@ -195,7 +223,7 @@ var pullCmd = star.Command{
 	Pos: []star.Positional{},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}
@@ -227,7 +255,7 @@ var pushCmd = star.Command{
 	Pos: []star.Positional{},
 	F: func(c star.Context) error {
 		ctx := c.Context
-		repo, close, err := openRepo()
+		repo, close, err := openRepo(c)
 		if err != nil {
 			return err
 		}

--- a/src/gotkv/tx.go
+++ b/src/gotkv/tx.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/gotvc/got/src/internal/stores"
+	"go.brendoncarroll.net/exp/iter2"
 	"go.brendoncarroll.net/exp/streams"
 )
 
@@ -110,7 +111,10 @@ func (tx *Tx) Delete(ctx context.Context, key []byte) error {
 	return nil
 }
 
-func (tx *Tx) IterateFlushed(ctx context.Context, span Span) *Iterator {
+func (tx *Tx) IterateFlushed(ctx context.Context, span Span) streams.Iterator[Entry] {
+	if tx.BaseIsZero() {
+		return streams.NewSeq(iter2.Empty[Entry]())
+	}
 	return tx.m.NewIterator(tx.s, tx.prev, span)
 }
 

--- a/src/gotns/gotns.go
+++ b/src/gotns/gotns.go
@@ -12,9 +12,9 @@ import (
 	"blobcache.io/blobcache/src/blobcache"
 	"github.com/gotvc/got/src/gdat"
 	"github.com/gotvc/got/src/gotkv"
+	"github.com/gotvc/got/src/internal/gotbc"
 	"github.com/gotvc/got/src/internal/gotcore"
 	"github.com/gotvc/got/src/internal/sbe"
-	"github.com/gotvc/got/src/internal/stores"
 	"github.com/gotvc/got/src/internal/volumes"
 	"go.brendoncarroll.net/exp/streams"
 )
@@ -262,9 +262,8 @@ func saveRoot(ctx context.Context, tx volumes.Tx, r Root) error {
 	return tx.Save(ctx, r.Marshal(nil))
 }
 
-func DefaultVolumeSpec() blobcache.VolumeSpec {
-	spec := blobcache.DefaultLocalSpec()
-	spec.Local.HashAlgo = blobcache.HashAlgo_BLAKE2b_256
-	spec.Local.MaxSize = stores.MaxSize
+// SpaceVolumeSpec returns a VolumeSpec for a got space
+func SpaceVolumeSpec() blobcache.VolumeSpec {
+	spec := gotbc.GotVolumeSpec()
 	return spec
 }

--- a/src/gotns/gotns.go
+++ b/src/gotns/gotns.go
@@ -17,15 +17,18 @@ import (
 	"github.com/gotvc/got/src/internal/sbe"
 	"github.com/gotvc/got/src/internal/volumes"
 	"go.brendoncarroll.net/exp/streams"
+	"go.brendoncarroll.net/stdctx/logctx"
 )
 
 func BeginTx(ctx context.Context, dmach *gdat.Machine, kvmach *gotkv.Machine, vol volumes.Volume, modify bool) (*Tx, error) {
 	ctx, cf := context.WithTimeoutCause(ctx, 3*time.Second, errors.New("trying to begin transaction"))
 	defer cf()
+	logctx.Debug(ctx, "gotns: BeginTx...")
 	tx, err := vol.BeginTx(ctx, blobcache.TxParams{Modify: modify})
 	if err != nil {
 		return nil, err
 	}
+	logctx.Debug(ctx, "gotns: started transaction")
 	return NewTx(tx, dmach, kvmach), nil
 }
 

--- a/src/gotns/space.go
+++ b/src/gotns/space.go
@@ -23,19 +23,7 @@ type Space struct {
 }
 
 func (s *Space) Do(ctx context.Context, modify bool, fn func(sptx gotcore.SpaceTx) error) error {
-	if modify {
-		return s.modify(ctx, func(tx *SpaceTx) error {
-			return fn(tx)
-		})
-	} else {
-		return s.view(ctx, func(tx *SpaceTx) error {
-			return fn(tx)
-		})
-	}
-}
-
-func (s *Space) modify(ctx context.Context, fn func(space *SpaceTx) error) error {
-	tx, err := BeginTx(ctx, s.DMach, s.KVMach, s.Volume, true)
+	tx, err := BeginTx(ctx, s.DMach, s.KVMach, s.Volume, modify)
 	if err != nil {
 		return err
 	}
@@ -47,20 +35,10 @@ func (s *Space) modify(ctx context.Context, fn func(space *SpaceTx) error) error
 	}); err != nil {
 		return err
 	}
-	return tx.Commit(ctx)
-}
-
-func (s *Space) view(ctx context.Context, fn func(space *SpaceTx) error) error {
-	tx, err := BeginTx(ctx, s.DMach, s.KVMach, s.Volume, false)
-	if err != nil {
-		return err
+	if modify {
+		return tx.Commit(ctx)
 	}
-	defer tx.Abort(ctx)
-	return fn(&SpaceTx{
-		kvmach: s.KVMach,
-		dmach:  s.DMach,
-		tx:     tx,
-	})
+	return nil
 }
 
 var _ gotcore.SpaceTx = &SpaceTx{}

--- a/src/gotns/space_test.go
+++ b/src/gotns/space_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSpace(t *testing.T) {
 	gotcore.TestSpace(t, func(t testing.TB) gotcore.Space {
-		spec := DefaultVolumeSpec()
+		spec := SpaceVolumeSpec()
 		bc, volh := schematests.Setup(t, map[blobcache.SchemaName]schema.Constructor{
 			"": schema.NoneConstructor,
 		}, *spec.Local)

--- a/src/gotorg/gotorg_test.go
+++ b/src/gotorg/gotorg_test.go
@@ -21,13 +21,9 @@ import (
 func TestInit(t *testing.T) {
 	ctx := testutil.Context(t)
 	bc := bclocal.NewTestService(t)
-	rootExpr := bcns.ObjectExpr{}
-	nsc, err := bcns.ClientForVolumeExpr(ctx, bc, rootExpr)
-	require.NoError(t, err)
-	nsh, err := rootExpr.Open(ctx, bc)
-	require.NoError(t, err)
+	nsc := bcns.NewClient(bc, blobcache.OID{})
 
-	volh, err := nsc.CreateAt(ctx, *nsh, "test", BranchVolumeSpec())
+	volh, err := nsc.CreateVolume(ctx, "test", BranchVolumeSpec())
 	require.NoError(t, err)
 
 	signPub, sigPriv := newTestSigner(t)
@@ -35,10 +31,10 @@ func TestInit(t *testing.T) {
 	gnsc := Client{Blobcache: bc, Machine: New(), ActAs: IdenPrivate{SigPrivateKey: sigPriv, KEMPrivateKey: kemPriv}}
 	adminLeaf := NewIDUnit(signPub, kemPub)
 	admins := []IdentityUnit{adminLeaf}
-	err = gnsc.EnsureInit(ctx, *volh, admins)
+	err = gnsc.EnsureInit(ctx, volh, admins)
 	require.NoError(t, err)
 
-	adminGrp, err := gnsc.LookupGroup(ctx, *volh, "admin")
+	adminGrp, err := gnsc.LookupGroup(ctx, volh, "admin")
 	require.NoError(t, err)
 	require.Equal(t, adminLeaf.ID, adminGrp.Owners[0])
 }

--- a/src/gotrepo/config.go
+++ b/src/gotrepo/config.go
@@ -89,8 +89,8 @@ func LoadConfig(repo *os.Root) (*Config, error) {
 }
 
 // editConfig applies fn to the config of the repo at repoPath
-func editConfig(repo *os.Root, fn func(x Config) Config) error {
-	return gotcfg.EditFile(repo, configPath, func(x Config) Config {
+func editConfig(repo *os.Root, fn func(x Config) (Config, error)) error {
+	return gotcfg.EditFile(repo, configPath, func(x Config) (Config, error) {
 		// maps
 		if x.Identities == nil {
 			x.Identities = make(map[string]inet256.ID)
@@ -110,18 +110,24 @@ func editConfig(repo *os.Root, fn func(x Config) Config) error {
 }
 
 func (r *Repo) Configure(ctx context.Context, fn func(x Config) Config) error {
+	return r.configure(ctx, func(x Config) (Config, error) {
+		return fn(x), nil
+	})
+}
+
+func (r *Repo) configure(ctx context.Context, fn func(x Config) (Config, error)) error {
 	if r.dir != nil {
 		if err := editConfig(r.dir, fn); err != nil {
 			return err
 		}
 	} else {
-		if err := r.repoc.EditConfig(ctx, r.rootVol, func(xData json.RawMessage) json.RawMessage {
+		if err := r.repoc.EditConfig(ctx, r.rootVol, func(xData json.RawMessage) (json.RawMessage, error) {
 			x, err := gotcfg.Parse[Config](xData)
 			if err != nil {
 				panic(err) // TODO: move Config into reposchema
 			}
-			y := fn(*x)
-			return gotcfg.Marshal(y)
+			y, err := fn(*x)
+			return gotcfg.Marshal(y), nil
 		}); err != nil {
 			return err
 		}

--- a/src/gotrepo/config.go
+++ b/src/gotrepo/config.go
@@ -109,13 +109,7 @@ func editConfig(repo *os.Root, fn func(x Config) (Config, error)) error {
 	})
 }
 
-func (r *Repo) Configure(ctx context.Context, fn func(x Config) Config) error {
-	return r.configure(ctx, func(x Config) (Config, error) {
-		return fn(x), nil
-	})
-}
-
-func (r *Repo) configure(ctx context.Context, fn func(x Config) (Config, error)) error {
+func (r *Repo) Configure(ctx context.Context, fn func(x Config) (Config, error)) error {
 	if r.dir != nil {
 		if err := editConfig(r.dir, fn); err != nil {
 			return err

--- a/src/gotrepo/iden.go
+++ b/src/gotrepo/iden.go
@@ -44,16 +44,16 @@ func (r *Repo) CreateIdentity(ctx context.Context, name string) (*inet256.ID, er
 	if err != nil {
 		return nil, err
 	}
-	if err := r.repoc.EditConfig(ctx, r.rootVol, func(xData json.RawMessage) json.RawMessage {
+	if err := r.repoc.EditConfig(ctx, r.rootVol, func(xData json.RawMessage) (json.RawMessage, error) {
 		x, err := gotcfg.Parse[Config](xData)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		if x.Identities == nil {
 			x.Identities = make(map[string]inet256.ID)
 		}
 		x.Identities[name] = id
-		return gotcfg.Marshal(*x)
+		return gotcfg.Marshal(*x), nil
 	}); err != nil {
 		return nil, err
 	}

--- a/src/gotrepo/internal/reposchema/client.go
+++ b/src/gotrepo/internal/reposchema/client.go
@@ -64,7 +64,7 @@ func (c *Client) GetNamespace(ctx context.Context, repoVol blobcache.OID, useSch
 	}
 
 	// ns doesn't exist, create it.
-	nsSpec := gotns.DefaultVolumeSpec()
+	nsSpec := gotns.SpaceVolumeSpec()
 	if !useSchema {
 		nsSpec.Local.Schema = blobcache.SchemaSpec{Name: blobcache.Schema_NONE}
 	}

--- a/src/gotrepo/internal/reposchema/client_test.go
+++ b/src/gotrepo/internal/reposchema/client_test.go
@@ -194,9 +194,9 @@ func TestConfigRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, cfg)
 
-	err = client.EditConfig(ctx, repoVol, func(prev json.RawMessage) json.RawMessage {
+	err = client.EditConfig(ctx, repoVol, func(prev json.RawMessage) (json.RawMessage, error) {
 		require.Nil(t, prev)
-		return json.RawMessage(`{"hello":"world"}`)
+		return json.RawMessage(`{"hello":"world"}`), nil
 	})
 	require.NoError(t, err)
 
@@ -204,9 +204,9 @@ func TestConfigRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"hello":"world"}`, string(cfg))
 
-	err = client.EditConfig(ctx, repoVol, func(prev json.RawMessage) json.RawMessage {
+	err = client.EditConfig(ctx, repoVol, func(prev json.RawMessage) (json.RawMessage, error) {
 		require.JSONEq(t, `{"hello":"world"}`, string(prev))
-		return nil
+		return nil, nil
 	})
 	require.NoError(t, err)
 

--- a/src/gotrepo/internal/reposchema/config.go
+++ b/src/gotrepo/internal/reposchema/config.go
@@ -36,7 +36,10 @@ func (c *Client) GetConfig(ctx context.Context, repoVol blobcache.OID) (json.Raw
 	return append(json.RawMessage(nil), cfg...), nil
 }
 
-func (c *Client) EditConfig(ctx context.Context, repoVol blobcache.OID, fn func(x json.RawMessage) json.RawMessage) error {
+// TODO: move config definition into this package.
+type Config = json.RawMessage
+
+func (c *Client) EditConfig(ctx context.Context, repoVol blobcache.OID, fn func(x Config) (Config, error)) error {
 	rootH, err := c.rootHandle(ctx, repoVol)
 	if err != nil {
 		return err
@@ -59,7 +62,10 @@ func (c *Client) EditConfig(ctx context.Context, repoVol blobcache.OID, fn func(
 	} else {
 		prev = append(json.RawMessage(nil), cfg...)
 	}
-	next := fn(prev)
+	next, err := fn(prev)
+	if err != nil {
+		return err
+	}
 	if next == nil {
 		root, err = c.gotkv.Delete(ctx, txn, root, configKey)
 		if err != nil {

--- a/src/gotrepo/repo.go
+++ b/src/gotrepo/repo.go
@@ -168,7 +168,7 @@ func (r *Repo) NSVolumeSpec(ctx context.Context) (*VolumeSpec, error) {
 		URL: blobcache.URL{
 			Node:   ep.Node,
 			IPPort: &ep.IPPort,
-			Base:   nsh.OID,
+			OID:    nsh.OID,
 		},
 		Secret: *secret,
 	}, nil

--- a/src/gotrepo/repo.go
+++ b/src/gotrepo/repo.go
@@ -64,8 +64,8 @@ func Init(ctx context.Context, bc blobcache.Service, volh blobcache.Handle, conf
 	if len(cfgData) != 0 {
 		return fmt.Errorf("repo volume has already been initialized")
 	}
-	if err := rc.EditConfig(ctx, volh.OID, func(x json.RawMessage) json.RawMessage {
-		return gotcfg.Marshal(config)
+	if err := rc.EditConfig(ctx, volh.OID, func(x json.RawMessage) (json.RawMessage, error) {
+		return gotcfg.Marshal(config), nil
 	}); err != nil {
 		return err
 	}
@@ -217,8 +217,8 @@ func (r *Repo) reloadConfig(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := r.repoc.EditConfig(ctx, r.rootVol, func(json.RawMessage) json.RawMessage {
-			return gotcfg.Marshal(cfg) // blind overwrite
+		if err := r.repoc.EditConfig(ctx, r.rootVol, func(json.RawMessage) (json.RawMessage, error) {
+			return gotcfg.Marshal(cfg), nil // blind overwrite
 		}); err != nil {
 			return err
 		}

--- a/src/gotrepo/repo_test.go
+++ b/src/gotrepo/repo_test.go
@@ -24,3 +24,39 @@ func TestRepoInit(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, repo)
 }
+
+func TestRenameSpace(t *testing.T) {
+	ctx := testutil.Context(t)
+	t.Parallel()
+	bc := gotbc.NewTest(t)
+	rootVol := blobcache.OID{}
+	volh, err := bc.OpenFiat(ctx, rootVol, blobcache.Action_ALL)
+	require.NoError(t, err)
+	require.NoError(t, Init(ctx, bc, *volh, DefaultConfig()))
+
+	repo, err := Open(ctx, bc, rootVol, nil)
+	require.NoError(t, err)
+
+	oldSpec := SpaceSpec{Blobcache: &VolumeSpec{}}
+
+	require.NoError(t, repo.Configure(ctx, func(x Config) (Config, error) {
+		x.Spaces["foo"] = oldSpec
+		x.Pull = append(x.Pull, PullConfig{From: "foo", AddPrefix: "x/"})
+		x.Push = append(x.Push, PushConfig{To: "foo", AddPrefix: "y/"})
+		return x, nil
+	}))
+
+	require.NoError(t, repo.RenameSpace(ctx, "foo", "bar"))
+
+	spaces, err := repo.ListSpaces(ctx)
+	require.NoError(t, err)
+	_, exists := spaces["foo"]
+	require.False(t, exists)
+	spec, exists := spaces["bar"]
+	require.True(t, exists)
+	require.Equal(t, oldSpec, spec)
+
+	cfg := repo.Config()
+	require.Equal(t, "bar", cfg.Pull[0].From)
+	require.Equal(t, "bar", cfg.Push[0].To)
+}

--- a/src/gotrepo/spaces.go
+++ b/src/gotrepo/spaces.go
@@ -40,14 +40,14 @@ func (r *Repo) AddSpace(ctx context.Context, name string, spec SpaceSpec) error 
 		return err
 	}
 	var success bool
-	if err := r.Configure(ctx, func(x Config) Config {
+	if err := r.Configure(ctx, func(x Config) (Config, error) {
 		if _, exists := x.Spaces[name]; exists {
-			return x
+			return x, nil
 		}
 
 		x.Spaces[name] = spec
 		success = true
-		return x
+		return x, nil
 	}); err != nil {
 		return err
 	}
@@ -58,16 +58,16 @@ func (r *Repo) AddSpace(ctx context.Context, name string, spec SpaceSpec) error 
 }
 
 func (r *Repo) RemoveSpace(ctx context.Context, name string) error {
-	return r.Configure(ctx, func(x Config) Config {
+	return r.Configure(ctx, func(x Config) (Config, error) {
 		delete(x.Spaces, name)
-		return x
+		return x, nil
 	})
 }
 
 // RenameSpace moves the space configured at oldName, to newName.
 // if there is already a Space at newName, then an error is returned.
 func (r *Repo) RenameSpace(ctx context.Context, oldName, newName string) error {
-	return r.configure(ctx, func(x Config) (Config, error) {
+	return r.Configure(ctx, func(x Config) (Config, error) {
 		spec, exists := x.Spaces[oldName]
 		if !exists {
 			return x, fmt.Errorf("%s does not exist", oldName)
@@ -115,12 +115,12 @@ func (r *Repo) makeSpace(ctx context.Context, spec SpaceSpec) (Space, error) {
 	switch {
 	case spec.Blobcache != nil:
 		bspec := *spec.Blobcache
-		logctx.Info(ctx, "opening url", zap.Stringer("url", bspec.URL))
+		logctx.Debug(ctx, "opening url", zap.Stringer("url", bspec.URL))
 		volh, err := bcsdk.OpenURL(ctx, r.bc, bspec.URL)
 		if err != nil {
 			return nil, err
 		}
-		logctx.Info(ctx, "opened volume for URL", zap.Stringer("url", bspec.URL))
+		logctx.Debug(ctx, "opened volume for URL", zap.Stringer("url", bspec.URL))
 		return spaceFromHandle(r.bc, *volh, &bspec.Secret), nil
 	default:
 		return nil, fmt.Errorf("empty SpaceSpec")

--- a/src/gotrepo/spaces.go
+++ b/src/gotrepo/spaces.go
@@ -33,7 +33,7 @@ func (r *Repo) GetSpace(ctx context.Context, name string) (gotcore.Space, error)
 	return r.makeSpace(ctx, spec)
 }
 
-func (r *Repo) CreateSpace(ctx context.Context, name string, spec SpaceSpec) error {
+func (r *Repo) AddSpace(ctx context.Context, name string, spec SpaceSpec) error {
 	if err := spec.Validate(); err != nil {
 		return err
 	}
@@ -53,6 +53,13 @@ func (r *Repo) CreateSpace(ctx context.Context, name string, spec SpaceSpec) err
 		return fmt.Errorf("a space with that name already exists")
 	}
 	return nil
+}
+
+func (r *Repo) RemoveSpace(ctx context.Context, name string) error {
+	return r.Configure(ctx, func(x Config) Config {
+		delete(x.Spaces, name)
+		return x
+	})
 }
 
 type VolumeSpec struct {

--- a/src/gotrepo/spaces.go
+++ b/src/gotrepo/spaces.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gotvc/got/src/gotns"
 	"github.com/gotvc/got/src/internal/gotcore"
 	"github.com/gotvc/got/src/internal/volumes"
+	"go.brendoncarroll.net/stdctx/logctx"
+	"go.uber.org/zap"
 )
 
 // ListSpaces lists all the spaces that the repository is configured to use
@@ -62,6 +64,23 @@ func (r *Repo) RemoveSpace(ctx context.Context, name string) error {
 	})
 }
 
+// RenameSpace moves the space configured at oldName, to newName.
+// if there is already a Space at newName, then an error is returned.
+func (r *Repo) RenameSpace(ctx context.Context, oldName, newName string) error {
+	return r.configure(ctx, func(x Config) (Config, error) {
+		spec, exists := x.Spaces[oldName]
+		if !exists {
+			return x, fmt.Errorf("%s does not exist", oldName)
+		}
+		if _, exists := x.Spaces[newName]; exists {
+			return x, fmt.Errorf("%s already exists", newName)
+		}
+		delete(x.Spaces, oldName)
+		x.Spaces[newName] = spec
+		return x, nil
+	})
+}
+
 type VolumeSpec struct {
 	URL    blobcache.URL `json:"url"`
 	Secret gdat.DEK      `json:"secret"`
@@ -96,10 +115,12 @@ func (r *Repo) makeSpace(ctx context.Context, spec SpaceSpec) (Space, error) {
 	switch {
 	case spec.Blobcache != nil:
 		bspec := *spec.Blobcache
+		logctx.Info(ctx, "opening url", zap.Stringer("url", bspec.URL))
 		volh, err := bcsdk.OpenURL(ctx, r.bc, bspec.URL)
 		if err != nil {
 			return nil, err
 		}
+		logctx.Info(ctx, "opened volume for URL", zap.Stringer("url", bspec.URL))
 		return spaceFromHandle(r.bc, *volh, &bspec.Secret), nil
 	default:
 		return nil, fmt.Errorf("empty SpaceSpec")

--- a/src/gotrepo/spaces.go
+++ b/src/gotrepo/spaces.go
@@ -66,6 +66,7 @@ func (r *Repo) RemoveSpace(ctx context.Context, name string) error {
 
 // RenameSpace moves the space configured at oldName, to newName.
 // if there is already a Space at newName, then an error is returned.
+// It also renames references in Pull and Push configurations.
 func (r *Repo) RenameSpace(ctx context.Context, oldName, newName string) error {
 	return r.Configure(ctx, func(x Config) (Config, error) {
 		spec, exists := x.Spaces[oldName]
@@ -77,6 +78,16 @@ func (r *Repo) RenameSpace(ctx context.Context, oldName, newName string) error {
 		}
 		delete(x.Spaces, oldName)
 		x.Spaces[newName] = spec
+		for i := range x.Pull {
+			if x.Pull[i].From == oldName {
+				x.Pull[i].From = newName
+			}
+		}
+		for i := range x.Push {
+			if x.Push[i].To == oldName {
+				x.Push[i].To = newName
+			}
+		}
 		return x, nil
 	})
 }

--- a/src/gottests/gottests.go
+++ b/src/gottests/gottests.go
@@ -83,7 +83,9 @@ func openSite(t testing.TB, root *os.Root) Site {
 }
 
 func (s *Site) ConfigureRepo(ctx context.Context, fn func(gotrepo.Config) gotrepo.Config) {
-	require.NoError(s.t, s.Repo.Configure(ctx, fn))
+	require.NoError(s.t, s.Repo.Configure(ctx, func(x gotrepo.Config) (gotrepo.Config, error) {
+		return fn(x), nil
+	}))
 }
 
 func (s *Site) ConfigureWC(ctx context.Context, fn func(gotwc.Config) gotwc.Config) {

--- a/src/gotwc/config.go
+++ b/src/gotwc/config.go
@@ -63,5 +63,7 @@ func LoadConfig(wcRoot *os.Root) (*Config, error) {
 }
 
 func EditConfig(wcRoot *os.Root, fn func(x Config) Config) error {
-	return gotcfg.EditFile(wcRoot, configPath, fn)
+	return gotcfg.EditFile(wcRoot, configPath, func(x Config) (Config, error) {
+		return fn(x), nil
+	})
 }

--- a/src/gotwc/workcopy.go
+++ b/src/gotwc/workcopy.go
@@ -11,6 +11,11 @@ import (
 
 	"blobcache.io/blobcache/src/bclocal"
 	"blobcache.io/blobcache/src/blobcache"
+	"go.brendoncarroll.net/exp/slices2"
+	"go.brendoncarroll.net/state/posixfs"
+	"go.brendoncarroll.net/stdctx/logctx"
+	"go.uber.org/zap"
+
 	"github.com/gotvc/got/src/gdat"
 	"github.com/gotvc/got/src/gotfs"
 	"github.com/gotvc/got/src/gotkv/kvstreams"
@@ -22,10 +27,6 @@ import (
 	"github.com/gotvc/got/src/gotwc/internal/staging"
 	"github.com/gotvc/got/src/internal/gotbc"
 	"github.com/gotvc/got/src/internal/gotcore"
-	"go.brendoncarroll.net/exp/slices2"
-	"go.brendoncarroll.net/state/posixfs"
-	"go.brendoncarroll.net/stdctx/logctx"
-	"go.uber.org/zap"
 )
 
 const (
@@ -36,6 +37,17 @@ const (
 	defaultDirMode  = 0o755
 	nameMaster      = "master"
 )
+
+func IsWC(wcRoot *os.Root) (bool, error) {
+	_, err := LoadConfig(wcRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
 
 // Init initializes a new working copy in wcdir
 // The working copy will be associated with the given repo.

--- a/src/internal/gotbc/blobcache.go
+++ b/src/internal/gotbc/blobcache.go
@@ -18,6 +18,7 @@ import (
 	"blobcache.io/blobcache/src/blobcache"
 	"github.com/cloudflare/circl/sign/ed25519"
 	"github.com/gotvc/got/src/gdat"
+	"github.com/gotvc/got/src/internal/stores"
 	"go.inet256.org/inet256/src/inet256"
 	"go.uber.org/zap"
 )
@@ -58,8 +59,8 @@ type EnvClientSpec struct {
 func GotVolumeSpec() blobcache.VolumeSpec {
 	return blobcache.VolumeSpec{
 		Local: &blobcache.VolumeBackend_Local{
-			HashAlgo: blobcache.HashAlgo_BLAKE2b_256,
-			MaxSize:  1 << 21,
+			HashAlgo: stores.HashAlgo,
+			MaxSize:  stores.MaxSize,
 			Salted:   false,
 		},
 	}
@@ -67,7 +68,7 @@ func GotVolumeSpec() blobcache.VolumeSpec {
 
 func newBCLogger() *zap.Logger {
 	cfg := zap.NewProductionConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zap.PanicLevel)
+	cfg.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
 	l, _ := cfg.Build()
 	return l
 }

--- a/src/internal/gotbc/intercept.go
+++ b/src/internal/gotbc/intercept.go
@@ -123,7 +123,7 @@ func (b *Local) Delete(ctx context.Context, tx blobcache.Handle, cids []blobcach
 	return b.svc.Delete(b.ctx(ctx), tx, cids)
 }
 
-func (b *Local) Copy(ctx context.Context, tx blobcache.Handle, srcTxns []blobcache.Handle, cids []blobcache.CID, success []bool) error {
+func (b *Local) Copy(ctx context.Context, tx blobcache.Handle, srcTxns []blobcache.Handle, cids []blobcache.CID, success *blobcache.BitMap) error {
 	return b.svc.Copy(b.ctx(ctx), tx, srcTxns, cids, success)
 }
 

--- a/src/internal/gotcfg/gotcfg.go
+++ b/src/internal/gotcfg/gotcfg.go
@@ -45,12 +45,15 @@ func LoadFile[T any](root *os.Root, p string) (*T, error) {
 	return Parse[T](data)
 }
 
-func EditFile[T any](root *os.Root, p string, fn func(T) T) error {
+func EditFile[T any](root *os.Root, p string, fn func(T) (T, error)) error {
 	cfg, err := LoadFile[T](root, p)
 	if err != nil {
 		return err
 	}
-	cfg2 := fn(*cfg)
+	cfg2, err := fn(*cfg)
+	if err != nil {
+		return err
+	}
 	// TODO: we should rename a new temp file into place.
 	return root.WriteFile(p, Marshal(cfg2), 0o644)
 }

--- a/src/internal/gotcore/spaces.go
+++ b/src/internal/gotcore/spaces.go
@@ -152,7 +152,10 @@ func CreateIfNotExists(ctx context.Context, stx SpaceTx, k string, cfg Metadata)
 // ForEach is a convenience function which uses Space.List to call fn with
 // all the mark names contained in span.
 func ForEach(ctx context.Context, stx SpaceTx, span Span, fn func(string) error) (retErr error) {
-	for name := range stx.All(ctx) {
+	for name, err := range stx.All(ctx) {
+		if err != nil {
+			return err
+		}
 		if !span.Contains(name) {
 			return fmt.Errorf("gotcore.ForEach: Space implementation is broken got %s when asking for %v", name, span)
 		}
@@ -251,7 +254,10 @@ func SyncSpaces(ctx context.Context, task SyncSpacesTask) ([]SyncResult, error) 
 	err := task.Src.Do(ctx, false, func(src SpaceTx) error {
 		return task.Dst.Do(ctx, true, func(dst SpaceTx) error {
 			nameMap := make(map[string]string)
-			for srcName := range src.All(ctx) {
+			for srcName, err := range src.All(ctx) {
+				if err != nil {
+					return err
+				}
 				// filter
 				if task.Filter != nil && !task.Filter(srcName) {
 					continue

--- a/src/internal/volumes/volumes.go
+++ b/src/internal/volumes/volumes.go
@@ -5,7 +5,6 @@ import (
 
 	"blobcache.io/blobcache/src/bcsdk"
 	"blobcache.io/blobcache/src/blobcache"
-	"github.com/gotvc/got/src/internal/stores"
 )
 
 type TxParams = blobcache.TxParams
@@ -27,39 +26,6 @@ type Tx interface {
 	Get(ctx context.Context, cid blobcache.CID, buf []byte) (int, error)
 	MaxSize() int
 	Hash(data []byte) blobcache.CID
-}
-
-func Modify(ctx context.Context, vol Volume, fn func(dst stores.RW, x []byte) ([]byte, error)) error {
-	tx, err := vol.BeginTx(ctx, TxParams{Modify: true})
-	if err != nil {
-		return err
-	}
-	defer tx.Abort(ctx)
-	var x []byte
-	if err := tx.Load(ctx, &x); err != nil {
-		return err
-	}
-	y, err := fn(tx, x)
-	if err != nil {
-		return err
-	}
-	if err := tx.Save(ctx, y); err != nil {
-		return err
-	}
-	return tx.Commit(ctx)
-}
-
-func View(ctx context.Context, vol Volume, fn func(src stores.RO, root []byte) error) error {
-	tx, err := vol.BeginTx(ctx, TxParams{Modify: false})
-	if err != nil {
-		return err
-	}
-	defer tx.Abort(ctx)
-	var root []byte
-	if err := tx.Load(ctx, &root); err != nil {
-		return err
-	}
-	return fn(tx, root)
 }
 
 // Blobcache is a volume backed by blobcache.


### PR DESCRIPTION
- `got repo edit` now calls the users editor with a JSON serialized config that the user can edit.
- `got bc create-space` creates a space using the Blobcache `bsns.Client`
- `got space mv` renames a space
- opening a repo will fallback to GOT_REPO for an OID if  there is no working copy in the current directory.